### PR TITLE
Fallback to vim.ui.select if Telescope is not found

### DIFF
--- a/docs/public_methods.md
+++ b/docs/public_methods.md
@@ -33,4 +33,4 @@ sets the selected environment.
 See: https://learn.microsoft.com/en-us/aspnet/core/test/http-files?view=aspnetcore-8.0#environment-files
 
 If you omit the `env_key`,
-it will try to load up a telescope prompt to select an environment.
+it will try to load up a telescope prompt to select an environment or fallback to using `vim.ui.select`.

--- a/lua/kulala/init.lua
+++ b/lua/kulala/init.lua
@@ -1,4 +1,5 @@
 local UI = require("kulala.ui")
+local SELECTOR = require("kulala.ui.selector")
 local ENV_PARSER = require("kulala.parser.env")
 local GLOBAL_STORE = require("kulala.global_store")
 local CONFIG = require("kulala.config")
@@ -29,14 +30,16 @@ M.toggle_view = function()
 end
 
 M.set_selected_env = function(env)
-  if not pcall(require, "telescope") and env == nil then
-    vim.notify("Telescope is not installed and env was not supplied..", vim.log.levels.ERROR)
-    return
-  elseif env == nil then
-    require("telescope").extensions.kulala.select_env()
-    return
-  end
-  GLOBAL_STORE.set("selected_env", env)
+	if env == nil then
+		local has_telescope, telescope = pcall(require, "telescope")
+		if has_telescope then
+			telescope.extensions.kulala.select_env()
+		else
+			SELECTOR.select_env()
+		end
+		return
+	end
+	GLOBAL_STORE.set("selected_env", env)
 end
 
 return M

--- a/lua/kulala/ui/selector.lua
+++ b/lua/kulala/ui/selector.lua
@@ -1,0 +1,27 @@
+local GLOBAL_STORE = require("kulala.global_store")
+
+local M = {}
+
+function M.select_env()
+	if not GLOBAL_STORE.get("http_client_env_json") then
+		return
+	end
+
+	local envs = {}
+	for key, _ in pairs(GLOBAL_STORE.get("http_client_env_json")) do
+		table.insert(envs, key)
+	end
+
+	local opts = {
+		prompt = "Select env",
+	}
+	vim.ui.select(envs, opts, function(result)
+		if not result then
+			return
+		end
+		GLOBAL_STORE.set("selected_env", result)
+		vim.g.kulala_selected_env = result
+	end)
+end
+
+return M


### PR DESCRIPTION
Currently the `set_selected_env` API only supports telescope. This changes it to fallback to using native `vim.ui.select`, which can already be mapped to other pickers by using something like [dressing](https://github.com/stevearc/dressing.nvim)