### PR TITLE
Add a warning that this only works on 0.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,6 @@ require('lazy').setup({
   },
 })
 ```
+
+> [!WARNING]
+> Requires Neovim 0.10.0+

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -2,7 +2,7 @@
 
 ### Neovim
 
-- [Neovim](https://github.com/neovim/neovim) (tested with 0.10.0)
+- [Neovim](https://github.com/neovim/neovim) 0.10.0+
   - [Treesitter for HTTP](https://github.com/nvim-treesitter/nvim-treesitter?tab=readme-ov-file#supported-languages) (`:TSInstall http`)
 
 ### cURL


### PR DESCRIPTION
It took me a while to realise that the reason it was failing was because I was on 0.9.5. Having this on the front page would be useful.