### PR TITLE
break: bump version

### DIFF
--- a/docs/_coverpage.md
+++ b/docs/_coverpage.md
@@ -1,4 +1,4 @@
-# kulala.nvim <small>1.5.1</small>
+# kulala.nvim <small>1.5.2</small>
 
 > A minimal 🤏 HTTP-client 🐼 interface 🖥️ for Neovim ❤️.
 

--- a/lua/kulala/globals/init.lua
+++ b/lua/kulala/globals/init.lua
@@ -2,7 +2,7 @@ local FS = require("kulala.utils.fs")
 
 local M = {}
 
-M.VERSION = "1.5.1"
+M.VERSION = "1.5.2"
 M.UI_ID = "kulala://ui"
 M.HEADERS_FILE = FS.get_plugin_tmp_dir() .. "/headers.txt"
 M.BODY_FILE = FS.get_plugin_tmp_dir() .. "/body.txt"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kulala.nvim",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "scripts": {
     "docs": "docsify serve docs"
   },


### PR DESCRIPTION
loading_done icon has now automatically a space after it, when its string length is greater than zero.