### PR TITLE
fix: allow other content types to be used

### DIFF
--- a/docs/_coverpage.md
+++ b/docs/_coverpage.md
@@ -1,4 +1,4 @@
-# kulala.nvim <small>2.0.0</small>
+# kulala.nvim <small>2.0.1</small>
 
 > A minimal 🤏 HTTP-client 🐼 interface 🖥️ for Neovim ❤️.
 

--- a/lua/kulala/globals/init.lua
+++ b/lua/kulala/globals/init.lua
@@ -2,7 +2,7 @@ local FS = require("kulala.utils.fs")
 
 local M = {}
 
-M.VERSION = "2.0.0"
+M.VERSION = "2.0.1"
 M.UI_ID = "kulala://ui"
 M.HEADERS_FILE = FS.get_plugin_tmp_dir() .. "/headers.txt"
 M.BODY_FILE = FS.get_plugin_tmp_dir() .. "/body.txt"

--- a/lua/kulala/parser/init.lua
+++ b/lua/kulala/parser/init.lua
@@ -279,7 +279,7 @@ function M.parse()
     if res.headers["content-type"] == "text/plain" then
       table.insert(res.cmd, "--data-raw")
       table.insert(res.cmd, res.body)
-    elseif res.headers["content-type"] == "application/json" then
+    elseif res.headers["content-type"]:match("application/[^/]+json") then
       table.insert(res.cmd, "--data")
       table.insert(res.cmd, res.body)
     elseif res.headers["content-type"] == "application/x-www-form-urlencoded" then

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kulala.nvim",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "scripts": {
     "docs": "docsify serve docs"
   },


### PR DESCRIPTION
The recent change broke something in my current `.http` calls because we're using a different content-type for json and it was sending out an empty body.

```http
POST http://{{hostname}}/api/users/login/
content-type: application/vnd.api+json

{
  "data": {
    "type": "User",
    "attributes": {
      "username": "johndoe",
      "password": "sample"
    }
  }
}
```

I tested this and it solves the issue I was having