### PR TITLE
fix(parser): don't set data when body is nil

### DIFF
--- a/lua/kulala/globals/init.lua
+++ b/lua/kulala/globals/init.lua
@@ -2,7 +2,7 @@ local FS = require("kulala.utils.fs")
 
 local M = {}
 
-M.VERSION = "2.5.0"
+M.VERSION = "2.5.1"
 M.UI_ID = "kulala://ui"
 M.HEADERS_FILE = FS.get_plugin_tmp_dir() .. "/headers.txt"
 M.BODY_FILE = FS.get_plugin_tmp_dir() .. "/body.txt"

--- a/lua/kulala/parser/init.lua
+++ b/lua/kulala/parser/init.lua
@@ -315,7 +315,7 @@ function M.parse()
   table.insert(res.cmd, PLUGIN_TMP_DIR .. "/body.txt")
   table.insert(res.cmd, "-X")
   table.insert(res.cmd, res.method)
-  if res.headers["content-type"] ~= nil then
+  if res.headers["content-type"] ~= nil and res.body ~= nil then
     if res.headers["content-type"]:find("^multipart/form%-data") then
       table.insert(res.cmd, "--data-binary")
       table.insert(res.cmd, res.body)

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
   "name": "kulala.nvim",
-  "version": "2.5.0"
+  "version": "2.5.1"
 }


### PR DESCRIPTION
The second request previously failed (exit code != 0) because `--data` was set even when body was `nil`. This is due to the newly introduced `DEFAULT_HEADERS`.

```http
POST https://httpbin.org/post HTTP/1.1
# @env-json-key AUTH_TOKEN json.token

{
  "username": "{{USERNAME}}",
  "password": "{{PASSWORD}}",
  "token": "foobar"
}

###

GET https://httpbin.org/get HTTP/1.1
authorization: Bearer {{AUTH_TOKEN}}
```

`http-client.env.json`

```json
{
  "_base": {
    "DEFAULT_HEADERS": {
      "Content-Type": "application/json",
      "Accept": "application/json"
    }
  },
  "dev": {
    "USERNAME": "gorillamoe",
    "PASSWORD": "bananas",
    "pokemon": "ditto",
    "auth_header": "Authorization: Basic Base64encodedstring=="
  },
  "prod": {
    "USERNAME": "marco",
    "PASSWORD": "polo",
    "pokemon": "pikachu",
    "auth_header": "Authorization: Basic Base64encodedstring=="
  }
}
```

This should be fixed now.