### PR TITLE
feat(parser): add @file-to-variable meta-tag

### DIFF
--- a/docs/docs/usage/file-to-variable.md
+++ b/docs/docs/usage/file-to-variable.md
@@ -1,0 +1,29 @@
+# File to variable
+
+Create a file with the `.http` extension and write your JSON request in it.
+
+Then, use the `@file-to-variable` directive to specify the variable name
+that you want to use in the request. The second argument is the path to the file.
+
+
+```http title="file-to-variable.http"
+POST https://httpbin.org/post HTTP/1.1
+content-type: application/json
+accept: application/json
+# @file-to-variable TEST_INCLUDE ./test-include.json
+
+{
+  "test-include": {{TEST_INCLUDE}}
+}
+
+```
+The `TEST_INCLUDE` variable will be replaced with the content of the `test-include.json` file.
+
+```json title="test-include.json"
+{
+  "foo": "bar",
+  "baz": {
+    "qux": "quux"
+  }
+}
+```

--- a/lua/kulala/globals/init.lua
+++ b/lua/kulala/globals/init.lua
@@ -2,7 +2,7 @@ local FS = require("kulala.utils.fs")
 
 local M = {}
 
-M.VERSION = "2.5.1"
+M.VERSION = "2.6.0"
 M.UI_ID = "kulala://ui"
 M.HEADERS_FILE = FS.get_plugin_tmp_dir() .. "/headers.txt"
 M.BODY_FILE = FS.get_plugin_tmp_dir() .. "/body.txt"

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
   "name": "kulala.nvim",
-  "version": "2.5.1"
+  "version": "2.6.0"
 }


### PR DESCRIPTION
Create a file with the `.http` extension and write your JSON request in it.

Then, use the `@file-to-variable` directive to specify the variable name
that you want to use in the request. The second argument is the path to the file.


```http title="file-to-variable.http"
POST https://httpbin.org/post HTTP/1.1
content-type: application/json
accept: application/json
# @file-to-variable TEST_INCLUDE ./test-include.json

{
  "test-include": {{TEST_INCLUDE}}
}

```
The `TEST_INCLUDE` variable will be replaced with the content of the `test-include.json` file.

```json title="test-include.json"
{
  "foo": "bar",
  "baz": {
    "qux": "quux"
  }
}
```

This also implements #72.