### PR TITLE
fix(env): early return causing nil env table error

### DIFF
--- a/lua/kulala/parser/env.lua
+++ b/lua/kulala/parser/env.lua
@@ -31,12 +31,12 @@ M.get_env = function()
   elseif dotenv then
     local dotenv_env = vim.fn.readfile(dotenv)
     for _, line in ipairs(dotenv_env) do
-      if line:match("^%s*$") or line:match("^%s*#") then
-        return
-      end
-      local key, value = line:match("^%s*([^=]+)%s*=%s*(.*)%s*$")
-      if key and value then
-        env[key] = value
+      -- if the line is not empy and not a comment, then
+      if not line:match("^%s*$") and not line:match("^%s*#") then
+        local key, value = line:match("^%s*([^=]+)%s*=%s*(.*)%s*$")
+        if key and value then
+          env[key] = value
+        end
       end
     end
   end


### PR DESCRIPTION
Early return inside this for loop is causing the assignment [here](https://github.com/mistweaverco/kulala.nvim/blob/main/lua/kulala/parser/init.lua#L22) to be nil when reading env variables from a `.env` file containing at least one empty line or a comment.