### PR TITLE
feat: add winbar for result buffer

### DIFF
--- a/lua/kulala/config/init.lua
+++ b/lua/kulala/config/init.lua
@@ -39,6 +39,8 @@ M.defaults = {
     '  "foo": "bar"',
     "}",
   },
+  -- enable winbar
+  winbar = false;
 }
 
 M.options = {}

--- a/lua/kulala/ui/init.lua
+++ b/lua/kulala/ui/init.lua
@@ -241,10 +241,14 @@ M.toggle_headers = function()
   CONFIG.set(cfg)
   if cfg.default_view == "body" then
     M.show_body()
-    toggle_winbar_tab("body")
+    if cfg.winbar then
+      toggle_winbar_tab("body")
+    end
   else
     M.show_headers()
-    toggle_winbar_tab("headers")
+    if cfg.winbar then
+      toggle_winbar_tab("headers")
+    end
   end
 end
 

--- a/lua/kulala/ui/init.lua
+++ b/lua/kulala/ui/init.lua
@@ -155,8 +155,14 @@ M.open = function()
         end
         if CONFIG.get().default_view == "body" then
           M.show_body()
+          if CONFIG.get().winbar then
+            toggle_winbar_tab("body")
+          end
         else
           M.show_headers()
+          if CONFIG.get().winbar then
+            toggle_winbar_tab("headers")
+          end
         end
       end
     end)
@@ -216,8 +222,14 @@ M.replay = function()
         end
         if CONFIG.get().default_view == "body" then
           M.show_body()
+          if CONFIG.get().winbar then
+            toggle_winbar_tab("body")
+          end
         else
           M.show_headers()
+          if CONFIG.get().winbar then
+            toggle_winbar_tab("headers")
+          end
         end
       end
     end)

--- a/lua/kulala/ui/winbar.lua
+++ b/lua/kulala/ui/winbar.lua
@@ -1,0 +1,47 @@
+local CONFIG = require("kulala.config")
+local M = {}
+
+---set winbar highlight
+M.winbar_sethl = function ()
+  vim.api.nvim_set_hl(0, "KulalaTab", { link = "TabLine" })
+  vim.api.nvim_set_hl(0, "KulalaTabSel", { link = "TabLineSel"})
+end
+
+---set local key mapping
+---@param buf integer|nil Buffer
+M.winbar_set_key_mapping = function (buf)
+  if buf then
+    vim.keymap.set('n', 'B', function ()
+      require("kulala.ui").toggle_headers()
+    end, { silent = true, buffer = buf })
+    vim.keymap.set('n', 'H', function ()
+      require("kulala.ui").toggle_headers()
+    end, { silent = true, buffer = buf })
+  end
+end
+
+---@param win_id integer|nil Window id
+---@param view string Body or headers
+M.toggle_winbar_tab = function (win_id, view)
+  if win_id then
+    if view == "body" then
+      vim.api.nvim_set_option_value("winbar", "%#KulalaTabSel# Body (B) %* %#KulalaTab# Headers (H) %* ", { win = win_id })
+    elseif view == "headers" then
+      vim.api.nvim_set_option_value("winbar", "%#KulalaTab# Body (B) %* %#KulalaTabSel# Headers (H) %* ", { win = win_id })
+    end
+  end
+end
+
+---set local key mapping
+---@param win_id integer|nil Window id
+---@param buf integer|nil Buffer
+M.create_winbar = function(win_id, buf)
+  if win_id then
+    local default_view = CONFIG.get().default_view
+    M.winbar_sethl()
+    M.toggle_winbar_tab(win_id, default_view)
+    M.winbar_set_key_mapping(buf)
+  end
+end
+
+return M


### PR DESCRIPTION
Adding "tabs" for the result buffer like in lazy.nvim 

![Screenshot_1](https://github.com/user-attachments/assets/a56fd2a8-643b-46b5-86ba-e9a709d1fafe)

To keep the original minimalism, I made this change optional and disabled by default in config, as it is essentially useless 😄