### PR TITLE
Response processing refactoring

### DIFF
--- a/docs/docs/getting-started/requirements.md
+++ b/docs/docs/getting-started/requirements.md
@@ -20,7 +20,7 @@ List of requirements for using kulala.
 
 ## xmllint
 
-- [xmllint](https://packages.ubuntu.com/noble/libxml2-utils) (tested with libxml v20914) (Only required for formatted XML/HTML responses)
+- [xmllint](https://packages.ubuntu.com/noble/libxml2-utils) (tested with libxml v20914) (Only required for formatted XML/HTML responses and resolving XML request variables)
 
 # Optional Requirements
 

--- a/docs/docs/getting-started/setup-options.md
+++ b/docs/docs/getting-started/setup-options.md
@@ -110,23 +110,135 @@ require("kulala").setup({
 })
 ```
 
-### formatters
+### content types
 
-Default formatters for different content types.
-
-Possible values:
-
-- `json = [command-table]`
-- `xml = [command-table]`
-- `html = [command-table]`
+Filetypes, formatters and path resolvers are defined for each content-type in an hash array
 
 Default:
 
 ```lua
-formatters = {
-  json = { "jq", "." },
-  xml = { "xmllint", "--format", "-" },
-  html = { "xmllint", "--format", "--html", "-" },
+content_types = {
+  ["application/json"] = {
+    ft = "json",
+    formatter = { "jq", "." },
+    pathresolver = require("kulala.parser.jsonpath").parse,
+  },
+  ["application/xml"] = {
+    ft = "xml",
+    formatter = { "xmllint", "--format", "-" },
+    pathresolver = { "xmllint", "--xpath", "{{path}}", "-" },
+  },
+  ["text/html"] = {
+    ft = "html",
+    formatter = { "xmllint", "--format", "--html", "-" },
+    pathresolver = {}, 
+  },
+}
+```
+
+#### filetypes
+
+Default filetype for the given content type.
+
+Possible values:
+
+Any filetype (`:help filetype`) neovim supports.
+
+Default:
+
+```lua
+content_types = {
+  ["application/json"] = {
+    ft = "json",
+  },
+  ["application/xml"] = {
+    ft = "xml",
+  },
+  ["text/html"] = {
+    ft = "html",
+  },
+```
+
+Example:
+
+```lua
+require("kulala").setup({
+  content_types = {
+    ["text/xml"] = {
+      ft = "xml",
+    },
+  },
+})
+```
+
+#### formatters
+
+Formatters take the response body and produce a beautified / more human readable output.
+
+Possible values:
+
+- You can define a commandline which processes the body. 
+  The body will be piped as stdin and the output will be used as the formatted body.
+- You can define a lua function `formatted_body = function(body)` which returns the formatted body.
+
+Default:
+
+```lua
+content_types = {
+  ["application/json"] = {
+    formatter = { "jq", "." },
+  },
+  ["application/xml"] = {
+    formatter = { "xmllint", "--format", "-" },
+  },
+  ["text/html"] = {
+    formatter = { "xmllint", "--format", "--html", "-" },
+  },
+}
+  ```
+
+Example:
+
+```lua
+require("kulala").setup({
+  content_types = {
+    ["text/plain"] = {
+      formatter = function(body)
+        return body:lower()
+      end,
+    },
+  },
+})
+```
+
+#### path resolvers
+
+You can use Request Variables to read values from requests / responses.
+To access a specific value inside a body Kulala gives you the possibility to define a path for it.
+This is normally JSONPath for JSON or XPath for XML but can be individually defined for any content type.
+
+Possible values:
+
+- You can use an external program which receives the full body as stdin and has to return the selected value in stdout.
+  The placeholder `{{path}}` can be used in any string of this defintion and will be replaced by the actual path (after `body.`).
+- Alternative you can give a lua function of `value = function(body, path)`.
+
+Default:
+
+Kulala has implemented a simple JSONPath parser which supports object traversal including array index access.
+For full JSONPath support you need to use an external program like `jsonpath-cli` or `jp`. 
+
+```lua
+content_types = {
+  ["application/json"] = {
+    pathresolver = require("kulala.parser.jsonpath").parse,
+  },
+  ["application/xml"] = {
+    pathresolver = { "xmllint", "--xpath", "{{path}}", "-" },
+  },
+  ["text/html"] = {
+    pathresolver = nil, 
+  },
 }
 ```
 
@@ -134,10 +246,10 @@ Example:
 
 ```lua
 require("kulala").setup({
-  formatters = {
-    json = { "jq", "." },
-    xml = { "xmllint", "--format", "-" },
-    html = { "xmllint", "--format", "--html", "-" },
+  content_types = {
+    ["text/xml"] = {
+      pathresolver = { "xmllint", "--xpath", "{{path}}", "-" },
+    },
   },
 })
 ```

--- a/docs/docs/usage/automatic-response-formatting.md
+++ b/docs/docs/usage/automatic-response-formatting.md
@@ -1,41 +1,24 @@
 # Automatic Response Formatting
 
-You can automatically format the response of an HTTP request using the `accept` header.
+You can automatically format the response of an HTTP request.
 
-For example, if you want to receive the response in JSON format, you can add the `accept: application/json` header.
+The response header will be parsed for the `Content-Type` value.
+If the content type has been defined in the `contentypes` section of the configuration and there is a `formatter` available, the response will be processed by the given beautifier.
 
-```http title="automatic-response-formatting.http"
-POST https://httpbin.org/post HTTP/1.1
-content-type: application/json
-accept: application/json
-
-{
-  "uuid": "{{$uuid}}",
-  "timestamp": "{{$timestamp}}",
-  "date": "{{$date}}",
-  "randomInt": "{{$randomInt}}",
-}
-
-```
 :::info
 
-You need to have external tools to format the response.
-For example, `jq` for JSON, `xmllint` for XML and HTML, etc.
+You need to have external tools to format the response, 
+for example `jq` for JSON or `xmllint` for XML and HTML,
+or you implement a lua function.
 
 :::
 
-### Supported Formats
-
-- JSON: `application/json`
-- XML: `application/xml`
-- HTML: `text/html`
-
 ### Default formatters
 
-```lua title="default-formatters.lua"
-formatters = {
-  json = { "jq", "." },
-  xml = { "xmllint", "--format", "-" },
-  html = { "xmllint", "--format", "--html", "-" },
-}
-```
+By default there are formatters defined for following types:
+
+- `application/json`
+- `application/xml`
+- `text/html`
+
+For details see the configuration section.

--- a/lua/kulala/cmd/init.lua
+++ b/lua/kulala/cmd/init.lua
@@ -1,6 +1,5 @@
 local GLOBALS = require("kulala.globals")
 local FS = require("kulala.utils.fs")
-local FORMATTER = require("kulala.formatter")
 local EXT_PROCESSING = require("kulala.external_processing")
 local INT_PROCESSING = require("kulala.internal_processing")
 
@@ -20,9 +19,6 @@ M.run = function(result, callback)
       local success = code == 0
       if success then
         local body = FS.read_file(GLOBALS.BODY_FILE)
-        if result.ft ~= "text" then
-          FS.write_file(GLOBALS.BODY_FILE, FORMATTER.format(result.ft, body))
-        end
         for _, metadata in ipairs(result.metadata) do
           if metadata then
             if metadata.name == "name" then

--- a/lua/kulala/config/init.lua
+++ b/lua/kulala/config/init.lua
@@ -1,3 +1,4 @@
+local FS = require("kulala.utils.fs")
 local M = {}
 
 M.defaults = {
@@ -8,11 +9,23 @@ M.defaults = {
   default_env = "dev",
   -- enable/disable debug mode
   debug = false,
-  -- default formatters for different content types
-  formatters = {
-    json = { "jq", "." },
-    xml = { "xmllint", "--format", "-" },
-    html = { "xmllint", "--format", "--html", "-" },
+  -- default formatters/pathresolver for different content types
+  contenttypes = {
+    ["application/json"] = {
+      ft = "json",
+      formatter = FS.command_exists("jq") and { "jq", "." } or nil,
+      pathresolver = require("kulala.parser.jsonpath").parse,
+    },
+    ["application/xml"] = {
+      ft = "xml",
+      formatter = FS.command_exists("xmllint") and { "xmllint", "--format", "-" } or nil,
+      pathresolver = FS.command_exists("xmllint") and { "xmllint", "--xpath", "{{path}}", "-" } or nil,
+    },
+    ["text/html"] = {
+      ft = "html",
+      formatter = FS.command_exists("xmllint") and { "xmllint", "--format", "--html", "-" } or nil,
+      pathresolver = nil, 
+    },
   },
   -- default icons
   icons = {
@@ -41,6 +54,12 @@ M.defaults = {
   },
   -- enable winbar
   winbar = false;
+}
+
+M.default_contenttype = {
+  ft = "plaintext",
+  formatter = nil,
+  pathresolver = nil,
 }
 
 M.options = {}

--- a/lua/kulala/formatter/init.lua
+++ b/lua/kulala/formatter/init.lua
@@ -1,26 +1,13 @@
-local CONFIG = require("kulala.config")
-local FS = require("kulala.utils.fs")
 local M = {}
 
-M.format = function(ft, contents)
-  local cfg = CONFIG.get()
-  local cmd = {}
-  local cmd_exists = false
-  if ft == "json" then
-    vim.inspect("formatting for json")
-    cmd = cfg.formatters.json
-    cmd_exists = FS.command_exists("jq")
-  elseif ft == "xml" then
-    cmd = cfg.formatters.xml
-    cmd_exists = FS.command_exists("xmllint")
-  elseif ft == "html" then
-    cmd = cfg.formatters.html
-    cmd_exists = FS.command_exists("xmllint")
+M.format = function(formatter, contents)
+  if type(formatter) == "function" then
+    return formatter(base_table[method].body)
+  elseif type(formatter) == "table" then
+    local cmd = formatter
+    return vim.system(cmd, { stdin = contents, text = true }):wait().stdout
   end
-  if not cmd_exists then
-    return contents
-  end
-  return vim.system(cmd, { stdin = contents, text = true }):wait().stdout
+  return contents
 end
 
 return M

--- a/lua/kulala/globals/init.lua
+++ b/lua/kulala/globals/init.lua
@@ -7,6 +7,5 @@ M.UI_ID = "kulala://ui"
 M.SCRATCHPAD_ID = "kulala://scratchpad"
 M.HEADERS_FILE = FS.get_plugin_tmp_dir() .. "/headers.txt"
 M.BODY_FILE = FS.get_plugin_tmp_dir() .. "/body.txt"
-M.FILETYPE_FILE = FS.get_plugin_tmp_dir() .. "/ft.txt"
 
 return M

--- a/lua/kulala/internal_processing/init.lua
+++ b/lua/kulala/internal_processing/init.lua
@@ -1,6 +1,7 @@
 local FS = require("kulala.utils.fs")
 local GLOBALS = require("kulala.globals")
 local DB = require("kulala.db")
+local CONFIG = require("kulala.config")
 local M = {}
 
 -- Function to access a nested key in a table dynamically
@@ -17,8 +18,8 @@ local function get_nested_value(t, key)
 end
 
 local get_headers_as_table = function()
-  local headers_file = FS.read_file(GLOBALS.HEADERS_FILE)
-  local lines = vim.split(headers_file, "\r\n")
+  local headers_file = FS.read_file(GLOBALS.HEADERS_FILE):gsub("\r\n", "\n")
+  local lines = vim.split(headers_file, "\n")
   local headers_table = {}
   for _, header in ipairs(lines) do
     if header:find(":") ~= nil then
@@ -40,6 +41,18 @@ local get_lower_headers_as_table = function()
     headers_table[key:lower()] = value
   end
   return headers_table
+end
+
+M.get_config_contenttype = function()
+  local headers = get_lower_headers_as_table()
+  if headers["content-type"] then
+    local content_type = vim.split(headers["content-type"], ";")[1]
+    local config = CONFIG.get().contenttypes[content_type]
+    if config then
+      return config
+    end
+  end
+  return CONFIG.default_contenttype
 end
 
 M.set_env_for_named_request = function(name, body)

--- a/lua/kulala/parser/init.lua
+++ b/lua/kulala/parser/init.lua
@@ -413,17 +413,8 @@ function M.parse()
     table.insert(res.cmd, additional_curl_option)
   end
   table.insert(res.cmd, res.url)
-  if res.headers["accept"] == "application/json" then
-    res.ft = "json"
-  elseif res.headers["accept"] == "application/xml" then
-    res.ft = "xml"
-  elseif res.headers["accept"] == "text/html" then
-    res.ft = "html"
-  end
   FS.delete_file(PLUGIN_TMP_DIR .. "/headers.txt")
   FS.delete_file(PLUGIN_TMP_DIR .. "/body.txt")
-  FS.delete_file(PLUGIN_TMP_DIR .. "/ft.txt")
-  FS.write_file(PLUGIN_TMP_DIR .. "/ft.txt", res.ft)
   if CONFIG.get().debug then
     FS.write_file(PLUGIN_TMP_DIR .. "/request.txt", table.concat(res.cmd, " "))
   end

--- a/lua/kulala/parser/jsonpath.lua
+++ b/lua/kulala/parser/jsonpath.lua
@@ -1,0 +1,42 @@
+local M = {}
+
+M.parse = function(body, path)
+  subpath = string.gsub(path, "^%$%.", "")
+
+  local result = vim.fn.json_decode(body)
+
+  local path_parts = {}
+
+  for part in string.gmatch(subpath, "[^%.%[%]\"']+") do
+    table.insert(path_parts, part)
+  end
+
+  for _, key in ipairs(path_parts) do
+    -- Check if the current result is a table (either an object or an array)
+    if type(result) == "table" then
+      -- If the key is a number (index), convert it to an integer and access the array element
+      local index = tonumber(key)
+      if index then
+        -- Lua arrays are 1-based, so we need to adjust the index
+        if result[index + 1] then
+          result = result[index + 1]
+        else
+          return nil -- Return nil if the index is out of bounds
+        end
+      else
+        -- Otherwise, assume it's a key in an object
+        if result[key] then
+          result = result[key]
+        else
+          return nil -- Return nil if the key is not found
+        end
+      end
+    else
+      return nil -- Return nil if result is not a table at this point
+    end
+  end
+
+  return result
+end
+
+return M

--- a/lua/kulala/ui/init.lua
+++ b/lua/kulala/ui/init.lua
@@ -6,6 +6,8 @@ local PARSER = require("kulala.parser")
 local CMD = require("kulala.cmd")
 local FS = require("kulala.utils.fs")
 local DB = require("kulala.db")
+local INT_PROCESSING = require("kulala.internal_processing")
+local FORMATTER = require("kulala.formatter")
 local M = {}
 
 local get_win = function ()
@@ -172,8 +174,11 @@ M.show_body = function()
       open_buffer()
     end
     local body = FS.read_file(GLOBALS.BODY_FILE)
-    local ft = FS.read_file(GLOBALS.FILETYPE_FILE)
-    set_buffer_contents(body, ft)
+    local contenttype = INT_PROCESSING.get_config_contenttype()
+    if contenttype.formatter then
+       body = FORMATTER.format(contenttype.formatter, body)
+    end
+    set_buffer_contents(body, contenttype.ft)
   else
     vim.notify("No body found", vim.log.levels.WARN)
   end
@@ -198,10 +203,13 @@ M.show_headers_body = function ()
       open_buffer()
     end
     local h = FS.read_file(GLOBALS.HEADERS_FILE)
-    local body = FS.read_file(GLOBALS.BODY_FILE)
-    local ft = FS.read_file(GLOBALS.FILETYPE_FILE)
     h = h:gsub("\r\n", "\n")
-    set_buffer_contents(h .. "\n" .. body, ft)
+    local body = FS.read_file(GLOBALS.BODY_FILE)
+    local contenttype = INT_PROCESSING.get_config_contenttype()
+    if contenttype.formatter then
+       body = FORMATTER.format(contenttype.formatter, body)
+    end
+    set_buffer_contents(h .. "\n" .. body, contenttype.ft)
   else
     vim.notify("No headers or body found", vim.log.levels.WARN)
   end


### PR DESCRIPTION

- Filetype from reponses `Content-Type` header:
  Formatting was done using the requests `Accept` header.
  This forces to specify the header and may destroy the respose body when another type is delivered (e.g. 404 HTML eror message).
  (temporary ft.txt will no longer be created)

- Filetype mapping by config: 
  The filetype mapping was fixed for `application/json`, `application/xml` and `text/html` in code.
  A new `contentypes` in the config allows you to define any (like missing `text/xml`) content-type.

- Formatter:
  **Breaking Change** The formatter are now also part of the above `contentypes` section.
  You can define a cmdline (as lua table like before) or newly a lua function with `formatted_body = function(body)` per content-type.

- Request Variables:
  The missing `(request|response).body.*` which gives you the full body as text (e.g. usable for Bearer-Authentications where the bearer comes a plaintext body) was added.
  XPath and JsonPath will no longer be distinguished by the beginning (e.g. `(//*/talent-score)[1]/text()` does nost start with `//` but is still a valid XPath).
  `contentypes` is here used for a per content-type definition, too.
  You can use a lua table for an external program which receives the full body as stdin and has to return the selected value in stdout.
  The placeholder `{{path}}` can be used in any string of this defintion.
  Alternative you can give a lua function of `value = function(body, path)`.
