### PR TITLE
Vscode rest client env support

### DIFF
--- a/docs/docs/getting-started/setup-options.md
+++ b/docs/docs/getting-started/setup-options.md
@@ -67,7 +67,9 @@ require("kulala").setup({
     "}",
   },
   -- enable winbar
-  winbar = false;
+  winbar = false,
+  -- enable reading vscode rest client environment variables
+  vscode_rest_client_environmentvars = false,
 })
 ```
 
@@ -428,6 +430,27 @@ Example:
 ```lua
 require("kulala").setup({
   winbar = false,
+})
+```
+
+### vscode_rest_client_environmentvars
+
+If enabled, Kulala searches for `.vscode/settings.json` or `*.code-workspace` files in the current directory and its parents to read the `rest-client.environmentVariables` definitions (`$shared` will be treated as `_base`).
+
+If `http-client.env.json` is also present, it will be merged (and overwrites variables from VSCode).
+
+Possible values:
+
+- `true`
+- `false`
+
+Default: `false`
+
+Example:
+
+```lua
+require("kulala").setup({
+  vscode_rest_client_environmentvars = true,
 })
 ```
 

--- a/lua/kulala/config/init.lua
+++ b/lua/kulala/config/init.lua
@@ -58,6 +58,8 @@ M.defaults = {
   },
   -- enable winbar
   winbar = false,
+  -- enable reading vscode rest client environment variables
+  vscode_rest_client_environmentvars = false,
 }
 
 M.default_contenttype = {

--- a/lua/kulala/globals/init.lua
+++ b/lua/kulala/globals/init.lua
@@ -2,7 +2,7 @@ local FS = require("kulala.utils.fs")
 
 local M = {}
 
-M.VERSION = "3.1.4"
+M.VERSION = "3.2.0"
 M.UI_ID = "kulala://ui"
 M.SCRATCHPAD_ID = "kulala://scratchpad"
 M.HEADERS_FILE = FS.get_plugin_tmp_dir() .. "/headers.txt"

--- a/lua/kulala/parser/env.lua
+++ b/lua/kulala/parser/env.lua
@@ -12,6 +12,44 @@ M.get_env = function()
   for key, value in pairs(vim.fn.environ()) do
     env[key] = value
   end
+  
+  DB.data.http_client_env_base = {}
+  DB.data.http_client_env = {}
+
+  if Config.get().vscode_rest_client_environmentvars then
+    local vscode_dir = FS.find_file_in_parent_dirs(".vscode")
+    local code_workspace_file = FS.find_file_in_parent_dirs(function(name, path)
+      return name:match('.*%.code%-workspace$')
+    end)
+
+    if vscode_dir then
+      local success, settings_json_content = pcall(vim.fn.readfile, vscode_dir .. "/settings.json")
+      if success then
+        local settings = vim.fn.json_decode(settings_json_content)
+        if settings and settings["rest-client.environmentVariables"] then
+          local f = settings["rest-client.environmentVariables"]
+          if f["$shared"] then
+            DB.data.http_client_env_base = vim.tbl_deep_extend("force", DB.data.http_client_env_base, f["$shared"])
+          end
+          f["$shared"] = nil
+          DB.data.http_client_env = vim.tbl_deep_extend("force", DB.data.http_client_env, f)
+        end
+      end  
+    end
+
+    if code_workspace_file then
+      local code_workspace = vim.fn.json_decode(vim.fn.readfile(code_workspace_file))
+      local settings = code_workspace.settings
+      if settings and settings["rest-client.environmentVariables"] then
+        local f = settings["rest-client.environmentVariables"]
+        if f["$shared"] then
+          DB.data.http_client_env_base = vim.tbl_deep_extend("force", DB.data.http_client_env_base, f["$shared"])
+        end
+        f["$shared"] = nil
+        DB.data.http_client_env = vim.tbl_deep_extend("force", DB.data.http_client_env, f)
+      end
+    end
+  end
 
   if dotenv then
     local dotenv_env = vim.fn.readfile(dotenv)
@@ -29,14 +67,21 @@ M.get_env = function()
   if http_client_env_json then
     local f = vim.fn.json_decode(vim.fn.readfile(http_client_env_json))
     if f._base then
-      DB.data.http_client_env_base = f._base
+      DB.data.http_client_env_base = vim.tbl_deep_extend("force", DB.data.http_client_env_base, f._base)
     end
     f._base = nil
-    DB.data.http_client_env = f
-    local selected_env = f[vim.g.kulala_selected_env or Config.get().default_env]
-    if selected_env then
-      env = vim.tbl_extend("force", env, selected_env)
+    DB.data.http_client_env = vim.tbl_deep_extend("force", DB.data.http_client_env, f)
+  end
+
+  for key, value in pairs(DB.data.http_client_env_base) do
+    if key ~= "DEFAULT_HEADERS" then 
+      env[key] = value
     end
+  end
+
+  local selected_env_name = DB.data.http_client_env[vim.g.kulala_selected_env or Config.get().default_env]
+  if selected_env then
+    env = vim.tbl_extend("force", env, selected_env)
   end
 
   for key, value in pairs(DB.data.env) do

--- a/lua/kulala/utils/fs.lua
+++ b/lua/kulala/utils/fs.lua
@@ -5,7 +5,7 @@ local M = {}
 --- @return string|nil
 --- @usage local p = fs.find_file_in_parent_dirs('Makefile')
 M.find_file_in_parent_dirs = function(filename)
-  return vim.fs.find({ filename }, {
+  return vim.fs.find(filename, {
     upward = true,
     limit = 1,
     path = vim.fn.expand("%:p:h"),


### PR DESCRIPTION
### vscode_rest_client_environmentvars

If enabled, Kulala searches for `.vscode/settings.json` or `*.code-workspace` files in the current directory and its parents to read the `rest-client.environmentVariables` definitions (`$shared` will be treated as `_base`).

If `http-client.env.json` is also present, it will be merged (and overwrites variables from VSCode).

Possible values:

- `true`
- `false`

Default: `false`

Example:

```lua
require("kulala").setup({
  vscode_rest_client_environmentvars = true,
})
```