### PR TITLE
fix: set_selected_env() does nothing

### DIFF
--- a/lua/kulala/globals/init.lua
+++ b/lua/kulala/globals/init.lua
@@ -2,7 +2,7 @@ local FS = require("kulala.utils.fs")
 
 local M = {}
 
-M.VERSION = "3.2.0"
+M.VERSION = "3.2.1"
 M.UI_ID = "kulala://ui"
 M.SCRATCHPAD_ID = "kulala://scratchpad"
 M.HEADERS_FILE = FS.get_plugin_tmp_dir() .. "/headers.txt"

--- a/lua/kulala/init.lua
+++ b/lua/kulala/init.lua
@@ -1,6 +1,6 @@
 local UI = require("kulala.ui")
 local SELECTOR = require("kulala.ui.selector")
-local DB = require("kulala.db")
+local ENV = require("kulala.parser.env")
 local GLOBALS = require("kulala.globals")
 local CONFIG = require("kulala.config")
 local JUMPS = require("kulala.jumps")
@@ -63,6 +63,7 @@ M.scratchpad = function()
 end
 
 M.set_selected_env = function(env)
+  ENV.get_env()
   if env == nil then
     local has_telescope, telescope = pcall(require, "telescope")
     if has_telescope then

--- a/lua/kulala/ui/selector.lua
+++ b/lua/kulala/ui/selector.lua
@@ -1,11 +1,9 @@
 local DB = require("kulala.db")
 local FS = require("kulala.utils.fs")
-local ENV_PARSER = require("kulala.parser.env")
 
 local M = {}
 
 function M.select_env()
-  ENV_PARSER.get_env()
   if not DB.data.http_client_env then
     return
   end

--- a/lua/kulala/ui/selector.lua
+++ b/lua/kulala/ui/selector.lua
@@ -1,9 +1,11 @@
 local DB = require("kulala.db")
 local FS = require("kulala.utils.fs")
+local ENV_PARSER = require("kulala.parser.env")
 
 local M = {}
 
 function M.select_env()
+  ENV_PARSER.get_env()
   if not DB.data.http_client_env then
     return
   end


### PR DESCRIPTION
Steps to reproduce:
1. Set a project directory with files:
```ansi
.
├── foo.http
└── http-client.env.json
```
2. Open `foo.http`
3. Run `require('kulala').set_selected_env()`.
4. Nothing happens.

Expected:
Telescope or vim.ui.selector appears to select env.