### PR TITLE
feat: support AWS-SigV4 authentication

### DIFF
--- a/docs/docs/usage/authentication.md
+++ b/docs/docs/usage/authentication.md
@@ -114,3 +114,19 @@ GET {{apiURL}}/items HTTP/1.1
 Accept: application/json
 Authorization: Bearer {{login.response.body.$.access_token}}
 ```
+
+## AWS Signature V4
+
+AWS Signature version 4 authenticates requests to AWS services.
+To use it you need to set the Authorization header schema to AWS and provide your AWS credentials separated by spaces:
+
+<access-key-id>: AWS Access Key Id
+<secret-access-key>: AWS Secret Access Key
+token:<aws-session-token>: AWS Session Token - required only for temporary credentials
+region:<region>: AWS Region
+service:<service>: AWS Service
+
+```http
+GET {{apiUrl}}/ HTTP/1.1
+Authorization: AWS <access-key-id> <secret-access-key> token:<aws-session-token> region:<region> service:<service>
+```


### PR DESCRIPTION
Hi:)

I work with AWS quite a lot and would like to use kulala for authenticating requests with [AWS Signature V4](https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html).
I took inspiration from https://github.com/Huachao/vscode-restclient and implemented this feature by parsing the authorization header and using the `--aws-sigv4` curl option.
A request to list all S3 buckets would look like this:
```http
GET https://s3.amazonaws.com/ HTTP/1.1
Authorization: AWS {{AWS_ACCESS_KEY_ID}} {{AWS_SECRET_ACCESS_KEY}} region:us-east-1 service:s3 token:{{AWS_SESSION_TOKEN}}
```

Let me know if you would be interested in merging this:)