### PR TITLE
fix: multipart/form-data

### DIFF
--- a/lua/kulala/parser/init.lua
+++ b/lua/kulala/parser/init.lua
@@ -469,7 +469,7 @@ function M.parse(start_request_linenr)
         res.headers["content-type"] = "application/json"
       end
     elseif res.headers["content-type"]:find("^multipart/form%-data") then
-      table.insert(res.cmd, "--data-binary")
+      table.insert(res.cmd, "--form")
       table.insert(res.cmd, res.body)
     else
       table.insert(res.cmd, "--data")


### PR DESCRIPTION
Hi, I simply fixed the option of `multipart/form-data`

Now it works with single field

(`multipart/form-date` requires the `-F/--form` option)

Also, the command to submit multiple fields is: `curl -F name=John -F shoesize=11 https://example.com/`

But I don't know how to implement it :(