### PR TITLE
Treesitter Parsing (again)

### DIFF
--- a/lua/kulala/config/init.lua
+++ b/lua/kulala/config/init.lua
@@ -60,6 +60,8 @@ M.defaults = {
   winbar = false,
   -- enable reading vscode rest client environment variables
   vscode_rest_client_environmentvars = false,
+  -- parse requests with tree-sitter
+  treesitter = false,
 }
 
 M.default_contenttype = {

--- a/lua/kulala/parser/init.lua
+++ b/lua/kulala/parser/init.lua
@@ -102,6 +102,10 @@ local function parse_body(body, variables, env)
 end
 
 M.get_document = function()
+  if CONFIG.get().treesitter then
+    return TS.get_document()
+  end
+
   local content_lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
   local content = table.concat(content_lines, "\n")
   local variables = {}

--- a/lua/kulala/parser/init.lua
+++ b/lua/kulala/parser/init.lua
@@ -8,6 +8,7 @@ local GRAPHQL_PARSER = require("kulala.parser.graphql")
 local REQUEST_VARIABLES = require("kulala.parser.request_variables")
 local STRING_UTILS = require("kulala.utils.string")
 local PARSER_UTILS = require("kulala.parser.utils")
+local TS = require("kulala.parser.treesitter")
 local PLUGIN_TMP_DIR = FS.get_plugin_tmp_dir()
 local Scripts = require("kulala.scripts")
 local Logger = require("kulala.logger")
@@ -387,8 +388,15 @@ function M.parse(start_request_linenr)
     },
   }
 
-  local document_variables, requests = M.get_document()
-  local req = M.get_request_at(requests, start_request_linenr)
+  local req, document_variables
+  if CONFIG:get().treesitter then
+    document_variables = TS.get_document_variables()
+    req = TS.get_request_at(start_request_linenr)
+  else
+    local requests
+    document_variables, requests = M.get_document()
+    req = M.get_request_at(requests, start_request_linenr)
+  end
   Scripts.javascript.run("pre_request", req.scripts.pre_request)
   local env = ENV_PARSER.get_env()
 

--- a/lua/kulala/parser/inspect.lua
+++ b/lua/kulala/parser/inspect.lua
@@ -15,7 +15,7 @@ M.get_contents = function()
   end
   if req.body ~= nil then
     table.insert(contents, "")
-    local body_as_table = vim.split(req.body, "\r\n")
+    local body_as_table = vim.split(req.body, "\r?\n")
     for _, line in ipairs(body_as_table) do
       table.insert(contents, line)
     end

--- a/lua/kulala/parser/treesitter.lua
+++ b/lua/kulala/parser/treesitter.lua
@@ -1,0 +1,173 @@
+local CONFIG = require("kulala.config")
+local FS = require("kulala.utils.fs")
+
+local M = {}
+
+local QUERIES = {}
+local function init_queries()
+  if QUERIES.section then
+    return
+  end
+
+  QUERIES.section = vim.treesitter.query.parse("http", "(section) @section")
+  QUERIES.variable = vim.treesitter.query.parse("http", "(variable_declaration) @variable")
+  QUERIES.request = vim.treesitter.query.parse("http", [[
+    (comment name: (_) value: (_)) @meta
+
+    (pre_request_script
+      (script)? @script.pre.inline
+      (path)? @script.pre.file)
+
+    (request
+      header: (header)? @header
+      body: (external_body)? @body.external) @request
+
+    (res_handler_script
+      (script)? @script.post.inline
+      (path)? @script.post.file)
+  ]])
+end
+
+local ROOT_NODE = nil
+local function get_root_node()
+  if not ROOT_NODE then
+    ROOT_NODE = vim.treesitter.get_parser(0, "http"):parse()[1]:root()
+  end
+  return ROOT_NODE
+end
+
+local function get_node_text(node)
+  if not node then
+    return nil
+  end
+
+  local text = vim.treesitter.get_node_text(node, 0)
+  return text:gsub("^%s*(.-)%s*$", "%1")
+end
+
+local function get_fields(node)
+  local tbl = {}
+  for child, field in node:iter_children() do
+    if field then
+      tbl[field] = get_node_text(child)
+    end
+  end
+  return tbl
+end
+
+M.get_document_variables = function()
+  init_queries()
+  local root = get_root_node()
+  local vars = {}
+
+  for _, node in QUERIES.variable:iter_captures(root, 0) do
+    local fields = get_fields(node)
+    vars[fields.name] = fields.value
+  end
+
+  return vars
+end
+
+local function new_request()
+  return {
+    url = "",
+    method = "",
+    http_version = "",
+    headers = {},
+    body = "",
+    metadata = {},
+    show_icon_line_number = nil,
+    redirect_response_body_to_files = {},
+    start_line = 0,
+    block_line_count = 0,
+    lines_length = 0,
+    scripts = {
+      pre_request = { inline = {}, files = {} },
+      post_request = { inline = {}, files = {} },
+    },
+  }
+end
+
+local function parse_request(section_node)
+  local req = new_request()
+
+  for i, node in QUERIES.request:iter_captures(section_node, 0) do
+    local capture = QUERIES.request.captures[i]
+    local fields = get_fields(node)
+
+    if capture == "request" then
+      local start_line, _, end_line, _ = node:range()
+      req.url = fields.url
+      req.method = fields.method
+      req.http_version = fields.http_version
+      req.body = fields.body
+      req.start_line = start_line
+      req.block_line_count = end_line - start_line
+      req.lines_length = end_line - start_line
+
+      req.show_icon_line_number = nil
+      local show_icons = CONFIG.get().show_icons
+      if show_icons ~= nil then
+        if show_icons == "on_request" then
+          req.show_icon_line_number = start_line + 1
+        elseif show_icons == "above_req" then
+          req.show_icon_line_number = start_line
+        elseif show_icons == "below_req" then
+          req.show_icon_line_number = end_line
+        end
+      end
+
+    elseif capture == "header" then
+      req.headers[fields.name:lower()] = fields.value
+
+    elseif capture == "meta" then
+      table.insert(req.metadata, fields)
+
+    elseif capture == "script.pre.inline" then
+      local script = get_node_text(node):gsub("{%%%s*(.-)%s*%%}", "%1")
+      table.insert(req.scripts.pre_request.inline, script)
+
+    elseif capture == "script.pre.file" then
+      local file = get_node_text(node)
+      table.insert(req.scripts.pre_request.files, file)
+
+    elseif capture == "script.post.inline" then
+      local script = get_node_text(node):gsub("{%%%s*(.-)%s*%%}", "%1")
+      table.insert(req.scripts.post_request.inline, script)
+
+    elseif capture == "script.post.file" then
+      local file = get_node_text(node)
+      table.insert(req.scripts.post_request.files, file)
+
+    elseif capture == "body.external" then
+      req.body = FS.read_file(fields.path)
+    end
+  end
+
+  return req
+end
+
+M.get_request_at = function(line)
+  line = line or vim.fn.line(".")
+  init_queries()
+  local root = get_root_node()
+
+  for _, section_node in QUERIES.section:iter_captures(root, 0, line, line) do
+    return parse_request(section_node)
+  end
+end
+
+M.get_all_requests = function()
+  init_queries()
+  local root = get_root_node()
+
+  local requests = {}
+  for _, section_node in QUERIES.section:iter_captures(root, 0) do
+    local req = parse_request(section_node)
+    table.insert(requests, req)
+  end
+
+  return requests
+end
+
+return M

--- a/lua/kulala/parser/treesitter.lua
+++ b/lua/kulala/parser/treesitter.lua
@@ -1,5 +1,6 @@
 local CONFIG = require("kulala.config")
 local FS = require("kulala.utils.fs")
+local STRING_UTILS = require("kulala.utils.string")
 
 local M = {}
 
@@ -20,7 +21,10 @@ local function init_queries()
 
     (request
       header: (header)? @header
-      body: (external_body)? @body.external) @request
+      body: [
+        (external_body) @body.external
+        (graphql_body) @body.graphql
+      ]?) @request
 
     (res_handler_script
       (script)? @script.post.inline
@@ -28,48 +32,120 @@ local function init_queries()
   ]])
 end
 
-local ROOT_NODE = nil
-local function get_root_node()
-  if not ROOT_NODE then
-    ROOT_NODE = vim.treesitter.get_parser(0, "http"):parse()[1]:root()
-  end
-  return ROOT_NODE
-end
-
-local function get_node_text(node)
+local function text(node)
   if not node then
     return nil
   end
 
-  local text = vim.treesitter.get_node_text(node, 0)
-  return text:gsub("^%s*(.-)%s*$", "%1")
+  local node_text = vim.treesitter.get_node_text(node, 0)
+  return STRING_UTILS.trim(node_text)
+end
+
+local REQUEST_VISITORS = {
+  request = function(req, node, fields)
+    local start_line, _, end_line, _ = node:range()
+    req.url = fields.url
+    req.method = fields.method
+    req.http_version = fields.http_version
+    req.body = fields.body
+    req.start_line = start_line
+    req.block_line_count = end_line - start_line
+    req.lines_length = end_line - start_line
+
+    req.show_icon_line_number = nil
+    local show_icons = CONFIG.get().show_icons
+    if show_icons ~= nil then
+      if show_icons == "on_request" then
+        req.show_icon_line_number = start_line + 1
+      elseif show_icons == "above_req" then
+        req.show_icon_line_number = start_line
+      elseif show_icons == "below_req" then
+        req.show_icon_line_number = end_line
+      end
+    end
+  end,
+
+  header = function(req, _, fields)
+    req.headers[fields.name:lower()] = fields.value
+  end,
+
+  meta = function(req, _, fields)
+    table.insert(req.metadata, fields)
+  end,
+
+  ["script.pre.inline"] = function(req, _, node)
+    local script = text(node):gsub("{%%%s*(.-)%s*%%}", "%1")
+    table.insert(req.scripts.pre_request.inline, script)
+  end,
+
+  ["script.pre.file"] = function(req, _, fields)
+    table.insert(req.scripts.pre_request.files, fields.path)
+  end,
+
+  ["script.post.inline"] = function(req, node, _)
+    local script = text(node):gsub("{%%%s*(.-)%s*%%}", "%1")
+    table.insert(req.scripts.post_request.inline, script)
+  end,
+
+  ["script.post.file"] = function(req, _, fields)
+    table.insert(req.scripts.post_request.files, fields.path)
+  end,
+
+  ["body.external"] = function(req, _, fields)
+    local contents = FS.read_file(fields.path)
+    if fields.path:match("%.graphql$") or fields.path:match("%.gql$") then
+      if req.method == "POST" then
+        req.body = string.format('{ "query": %q }', STRING_UTILS.remove_newline(contents))
+        req.headers['content-type'] = "application/json"
+      else
+        local query = STRING_UTILS.url_encode(
+          STRING_UTILS.remove_extra_space(
+            STRING_UTILS.remove_newline(contents)
+          )
+        )
+        req.url = string.format("%s?query=%s", req.url, query)
+        req.body = nil
+      end
+    else
+      req.body = contents
+    end
+  end,
+
+  ["body.graphql"] = function(req, node, _)
+    local json_body = {}
+
+    for child in node:iter_children() do
+      if child:type() == "graphql_data" then
+        json_body.query = text(child)
+      elseif child:type() == "json_body" then
+        local variables_str = text(child)
+        json_body.variables = vim.fn.json_decode(variables_str)
+      end
+    end
+
+    if #json_body.query > 0 then
+      req.body = vim.fn.json_encode(json_body)
+      req.headers['content-type'] = "application/json"
+    end
+  end,
+}
+
+local function get_root_node()
+  return vim.treesitter.get_parser(0, "http"):parse()[1]:root()
 end
 
 local function get_fields(node)
   local tbl = {}
   for child, field in node:iter_children() do
     if field then
-      tbl[field] = get_node_text(child)
+      tbl[field] = text(child)
     end
   end
   return tbl
 end
 
-M.get_document_variables = function()
-  init_queries()
-  local root = get_root_node()
-  local vars = {}
-
-  for _, node in QUERIES.variable:iter_captures(root, 0) do
-    local fields = get_fields(node)
-    vars[fields.name] = fields.value
-  end
-
-  return vars
-end
-
-local function new_request()
-  return {
+local function parse_request(section_node)
+  local req = {
     url = "",
     method = "",
     http_version = "",
@@ -86,65 +162,30 @@ local function new_request()
       post_request = { inline = {}, files = {} },
     },
   }
-end
-
-local function parse_request(section_node)
-  local req = new_request()
 
   for i, node in QUERIES.request:iter_captures(section_node, 0) do
     local capture = QUERIES.request.captures[i]
     local fields = get_fields(node)
 
-    if capture == "request" then
-      local start_line, _, end_line, _ = node:range()
-      req.url = fields.url
-      req.method = fields.method
-      req.http_version = fields.http_version
-      req.body = fields.body
-      req.start_line = start_line
-      req.block_line_count = end_line - start_line
-      req.lines_length = end_line - start_line
-
-      req.show_icon_line_number = nil
-      local show_icons = CONFIG.get().show_icons
-      if show_icons ~= nil then
-        if show_icons == "on_request" then
-          req.show_icon_line_number = start_line + 1
-        elseif show_icons == "above_req" then
-          req.show_icon_line_number = start_line
-        elseif show_icons == "below_req" then
-          req.show_icon_line_number = end_line
-        end
-      end
-
-    elseif capture == "header" then
-      req.headers[fields.name:lower()] = fields.value
-
-    elseif capture == "meta" then
-      table.insert(req.metadata, fields)
-
-    elseif capture == "script.pre.inline" then
-      local script = get_node_text(node):gsub("{%%%s*(.-)%s*%%}", "%1")
-      table.insert(req.scripts.pre_request.inline, script)
-
-    elseif capture == "script.pre.file" then
-      local file = get_node_text(node)
-      table.insert(req.scripts.pre_request.files, file)
-
-    elseif capture == "script.post.inline" then
-      local script = get_node_text(node):gsub("{%%%s*(.-)%s*%%}", "%1")
-      table.insert(req.scripts.post_request.inline, script)
-
-    elseif capture == "script.post.file" then
-      local file = get_node_text(node)
-      table.insert(req.scripts.post_request.files, file)
-
-    elseif capture == "body.external" then
-      req.body = FS.read_file(fields.path)
+    if REQUEST_VISITORS[capture] then
+      REQUEST_VISITORS[capture](req, node, fields)
     end
   end
 
   return req
+end
+
+M.get_document_variables = function()
+  init_queries()
+  local root = get_root_node()
+  local vars = {}
+
+  for _, node in QUERIES.variable:iter_captures(root, 0) do
+    local fields = get_fields(node)
+    vars[fields.name] = fields.value
+  end
+
+  return vars
 end
 
 M.get_request_at = function(line)

--- a/lua/kulala/ui/init.lua
+++ b/lua/kulala/ui/init.lua
@@ -187,7 +187,6 @@ M.open_all = function()
   local requests
   if CONFIG:get().treesitter then
     requests = TS.get_all_requests()
-    vim.print(#requests)
   else
     _, requests = PARSER.get_document()
   end

--- a/lua/kulala/ui/init.lua
+++ b/lua/kulala/ui/init.lua
@@ -9,6 +9,8 @@ local FS = require("kulala.utils.fs")
 local DB = require("kulala.db")
 local INT_PROCESSING = require("kulala.internal_processing")
 local FORMATTER = require("kulala.formatter")
+local TS = require("kulala.parser.treesitter")
+
 local Inspect = require("kulala.parser.inspect")
 local M = {}
 
@@ -182,8 +184,15 @@ end
 
 M.open_all = function()
   INLAY.clear()
-  local _, doc = PARSER.get_document()
-  CMD.run_parser_all(doc, function(success, start, icon_linenr)
+  local requests
+  if CONFIG:get().treesitter then
+    requests = TS.get_all_requests()
+    vim.print(#requests)
+  else
+    _, requests = PARSER.get_document()
+  end
+
+  CMD.run_parser_all(requests, function(success, start, icon_linenr)
     if not success then
       if icon_linenr then
         INLAY:show_error(icon_linenr)

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -1,2 +1,0 @@
-const randomDate = new Date().toLocaleString();
-client.global.set('RANDOM_DATE', randomDate);

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -1,0 +1,2 @@
+const randomDate = new Date().toLocaleString();
+client.global.set('RANDOM_DATE', randomDate);


### PR DESCRIPTION
follow up to #181

* make `run_all` work with treesitter
* fix graphql requests
* general cleanup

what doesn't work (yet):
* redirecting response bodies to a file, since the `>>` and `>>!` operators aren't part of the http grammar. I opened a [pull request](https://github.com/rest-nvim/tree-sitter-http/pull/40) to add this to the grammar, and have it implemented in my kulala fork in a [separate branch](https://github.com/treywood/kulala.nvim/compare/fix-treesitter-bugs...treywood:kulala.nvim:treesitter-response-redirect)