### PR TITLE
implement response redirect with treesitter

### DIFF
--- a/lua/kulala/parser/init.lua
+++ b/lua/kulala/parser/init.lua
@@ -371,6 +371,9 @@ M.get_request_at = function(requests, linenr)
   if linenr == nil then
     linenr = vim.api.nvim_win_get_cursor(0)[1]
   end
+  if CONFIG.get().treesitter then
+    return TS.get_request_at(linenr - 1)
+  end
   for _, request in ipairs(requests) do
     if linenr >= request.start_line and linenr <= request.end_line then
       return request

--- a/lua/kulala/parser/treesitter.lua
+++ b/lua/kulala/parser/treesitter.lua
@@ -33,6 +33,9 @@ local QUERIES = {
       ((script) @script.post.inline
         (#offset! @script.post.inline 0 2 0 -2))?
       (path)? @script.post.file)
+
+    (res_redirect
+      path: (path)) @redirect
   ]]
   ),
 }
@@ -130,6 +133,18 @@ local REQUEST_VISITORS = {
       req.headers["content-type"] = "application/json"
     end
   end,
+
+  redirect = function(req, args)
+    local overwrite = false
+    if args.text:match("^>>!") then
+      overwrite = true
+    end
+
+    table.insert(req.redirect_response_body_to_files, {
+      file = args.fields.path,
+      overwrite = overwrite,
+    })
+  end,
 }
 
 local function get_root_node()
@@ -193,7 +208,7 @@ M.get_document_variables = function(root)
 end
 
 M.get_request_at = function(line)
-  line = line or vim.fn.line(".")
+  line = line or (vim.fn.line(".") - 1)
   local root = get_root_node()
 
   for i, node in QUERIES.section:iter_captures(root, 0, line, line) do

--- a/lua/kulala/parser/treesitter.lua
+++ b/lua/kulala/parser/treesitter.lua
@@ -225,7 +225,11 @@ M.get_all_requests = function(root)
   for i, node in QUERIES.section:iter_captures(root, 0) do
     if QUERIES.section.captures[i] == "request" then
       local start_line, _, end_line, _ = node:range()
-      table.insert(requests, { start_line = start_line, end_line = end_line })
+      table.insert(requests, {
+        start_line = start_line,
+        end_line = end_line,
+        metadata = {},
+      })
     end
   end
 

--- a/lua/kulala/ui/init.lua
+++ b/lua/kulala/ui/init.lua
@@ -235,13 +235,7 @@ end
 
 M.open_all = function()
   INLAY.clear()
-  local requests
-  if CONFIG:get().treesitter then
-    requests = TS.get_all_requests()
-  else
-    _, requests = PARSER.get_document()
-  end
-
+  local _, requests = PARSER.get_document()
   CMD.run_parser_all(requests, function(success, start, icon_linenr)
     if not success then
       if icon_linenr then


### PR DESCRIPTION
can merge when https://github.com/rest-nvim/tree-sitter-http/pull/40 is merged and picked up by `nvim-treesitter`

also move all calls to treesitter parsing into the parser module, fix some bugs