### PR TITLE
feat(checkhealth): support for neovim :checkhealth feature

### DIFF
--- a/lua/kulala/health.lua
+++ b/lua/kulala/health.lua
@@ -1,23 +1,30 @@
+local CONFIG = require("kulala.config")
+local GLOBALS = require("kulala.globals")
+local FS = require("kulala.utils.fs")
+
 local health = vim.health
 local start = health.start
 local ok = health.ok
+local info = health.info
+local warn = health.warn
 local error = health.error
-local is_win = vim.api.nvim_call_function("has", { "win32" }) == 1
 
 local M = {}
 
 M.check = function()
-  start("Checking external dependencies")
-  local deps = { "curl", "jq", "xmllint" }
-  for _, dep in pairs(deps) do
-    if is_win then
-      dep = dep .. ".exe"
-    end
-    local found = (vim.fn.executable(dep) == 1)
-    if found then
-      ok(string.format("Found %s", dep))
+  info("{kulala.nvim} version " .. GLOBALS.VERSION)
+  if FS.command_exists("curl") then
+    ok("{curl} found")
+  else
+    error("{curl} not found")
+  end
+
+  start("Checking formatters")
+  for type, config in pairs(CONFIG.get().contenttypes) do
+    if not config.formatter then
+      warn(string.format("{%s} formatter not found", type))
     else
-      error(string.format("Missing %s", dep))
+      ok(string.format("{%s} formatter: %s", type, table.concat(config.formatter, " ")))
     end
   end
 end

--- a/lua/kulala/health.lua
+++ b/lua/kulala/health.lua
@@ -1,0 +1,25 @@
+local health = vim.health
+local start = health.start
+local ok = health.ok
+local error = health.error
+local is_win = vim.api.nvim_call_function("has", { "win32" }) == 1
+
+local M = {}
+
+M.check = function()
+  start("Checking external dependencies")
+  local deps = { "curl", "jq", "xmllint" }
+  for _, dep in pairs(deps) do
+    if is_win then
+      dep = dep .. ".exe"
+    end
+    local found = (vim.fn.executable(dep) == 1)
+    if found then
+      ok(string.format("Found %s", dep))
+    else
+      error(string.format("Missing %s", dep))
+    end
+  end
+end
+
+return M


### PR DESCRIPTION
Support for neovim health check protocol
https://neovim.io/doc/user/health.html Windows supported too.

`:checkhealth kulala` prints following.

```
==============================================================================
kulala: require("kulala.health").check()

- {kulala.nvim} version 3.7.0
- OK {curl} found

Checking formatters ~
- OK {text/html} formatter: xmllint --format --html -
- WARNING {application/json} formatter not found
- OK {application/xml} formatter: xmllint --format -

```

Inspired by MIT licensed telescope healthcheck
https://github.com/nvim-telescope/telescope.nvim/blob/master/lua/telescope/health.lua and https://github.com/folke/lazy.nvim/blob/main/lua/lazy/health.lua
