### PR TITLE
[not urgent] enable treesitter parsing by default

### DIFF
--- a/docs/docs/getting-started/configuration-options.md
+++ b/docs/docs/getting-started/configuration-options.md
@@ -93,6 +93,11 @@ Here is a full example of setting up the Kulala plugin with the available `opts`
     -- set scope for environment and request variables
     -- possible values: b = buffer, g = global
     environment_scope = "b",
+
+    -- by default, requests are parsed using treesitter if an http parser is available.
+    -- if you encounter tree-sitter related issues, you can disable this feature
+    -- by setting this option to false (and then open an issue on GitHub!)
+    treesitter = true,
   },
 }
 ```

--- a/lua/kulala/config/init.lua
+++ b/lua/kulala/config/init.lua
@@ -1,6 +1,18 @@
 local FS = require("kulala.utils.fs")
 local M = {}
 
+-- enable treesitter parsing by default if http parser is available
+local treesitter_default = false
+local ok, parsers = pcall(require, "nvim-treesitter.parsers")
+if ok then
+  for _, parser in pairs(parsers.available_parsers()) do
+    if parser == "http" then
+      treesitter_default = true
+      break
+    end
+  end
+end
+
 M.defaults = {
   -- split direction
   -- possible values: "vertical", "horizontal"
@@ -64,7 +76,7 @@ M.defaults = {
   -- enable reading vscode rest client environment variables
   vscode_rest_client_environmentvars = false,
   -- parse requests with tree-sitter
-  treesitter = false,
+  treesitter = treesitter_default,
   -- disable the vim.print output of the scripts
   -- they will be still written to disk, but not printed immediately
   disable_script_print_output = false,

--- a/lua/kulala/parser/treesitter.lua
+++ b/lua/kulala/parser/treesitter.lua
@@ -1,7 +1,3 @@
-if not pcall(require, "nvim-treesitter") then
-  return nil
-end
-
 local CONFIG = require("kulala.config")
 local FS = require("kulala.utils.fs")
 local STRING_UTILS = require("kulala.utils.string")


### PR DESCRIPTION
I've been thinking about how to start enabling tree-sitter parsing by default, and I think this might be a good way to go about it - the `treesitter` option is set to true by default if the user has an http parser installed, and documentation encourages the user to try setting this option to false if they encounter an issue.

No rush to merge this, but curious about thoughts on the approach