### PR TITLE
fix(shlex): make split function more robust

### DIFF
--- a/lua/kulala/lib/shlex/init.lua
+++ b/lua/kulala/lib/shlex/init.lua
@@ -53,8 +53,8 @@ function M.shlex:create(str, posix, punctuation_chars)
   o.posix = posix == true
   if o.posix then
     o.wordchars = o.wordchars
-        .. "ßàáâãäåæçèéêëìíîïðñòóôõöøùúûüýþÿ"
-        .. "ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ"
+      .. "ßàáâãäåæçèéêëìíîïðñòóôõöøùúûüýþÿ"
+      .. "ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞ"
   end
 
   if punctuation_chars then
@@ -222,10 +222,13 @@ function M.shlex:read_token()
       elseif not continue and self.posix and self.escape:find(nextchar, 1, true) then
         escapedstate = "a"
         self.state = nextchar
-      elseif not continue and
-          (self.wordchars:find(nextchar, 1, true)
-            or self.quotes:find(nextchar, 1, true)
-            or (self.whitespace_split and not self.punctuation_chars:find(nextchar, 1, true)))
+      elseif
+        not continue
+        and (
+          self.wordchars:find(nextchar, 1, true)
+          or self.quotes:find(nextchar, 1, true)
+          or (self.whitespace_split and not self.punctuation_chars:find(nextchar, 1, true))
+        )
       then
         self.token = self.token .. nextchar
       elseif not continue then

--- a/tests/lib/shlex/shlex_spec.lua
+++ b/tests/lib/shlex/shlex_spec.lua
@@ -62,7 +62,7 @@ foo#bar\nbaz|foo|baz|
 áéíóú|áéíóú|
 ]]
 
--- broken data are test cases, works well in CPython shlex, but do not in Lua version
+-- broken data are test cases which works well in CPython shlex, but do not in Lua version
 local broken_data = [[
 foo "" bar|foo||bar|
 foo '' bar|foo||bar|
@@ -132,10 +132,7 @@ end)
 describe("broken", function()
   for input, expected in test_cases(broken_data) do
     it("'" .. input .. "'", function()
-      local shlex = SHLEX.shlex:create(input, true, nil)
-      shlex.debug = 0
-      shlex.whitespace_split = true
-      local actual = shlex:list()
+      local actual = SHLEX.split(input)
       assert.is_not.same(expected, actual)
     end)
   end

--- a/tests/lib/shlex/shlex_spec.lua
+++ b/tests/lib/shlex/shlex_spec.lua
@@ -76,7 +76,9 @@ local function splitlines(str, sep)
   end
   local pos = 0
   return function()
-    if pos >= #str then return nil end
+    if pos >= #str then
+      return nil
+    end
     local s, e = str:find(sep, pos)
     local line = str:sub(pos, s and s - 1)
     pos = (e or #str) + 1
@@ -98,7 +100,9 @@ local function test_cases(str)
   local it = splitlines(str)
   return function()
     local line = it()
-    if line == nil then return nil end
+    if line == nil then
+      return nil
+    end
     local expected = split(line, "|")
     local input = expected[1]
     input = input:gsub("\\n", "\n")

--- a/tests/lib/shlex/shlex_spec.lua
+++ b/tests/lib/shlex/shlex_spec.lua
@@ -1,0 +1,138 @@
+local SHLEX = require("kulala.lib.shlex")
+
+-- testing data from cpython implementation
+-- https://github.com/python/cpython/blob/4a6b1f179667e2a8c6131718eb78a15f726e047b/Lib/test/test_shlex.py#L73
+local posix_data = [[x|x|
+foo bar|foo|bar|
+foo bar|foo|bar|
+foo bar |foo|bar|
+foo   bar    bla     fasel|foo|bar|bla|fasel|
+x y  z              xxxx|x|y|z|xxxx|
+\x bar|x|bar|
+\ x bar| x|bar|
+\ bar| bar|
+foo \x bar|foo|x|bar|
+foo \ x bar|foo| x|bar|
+foo \ bar|foo| bar|
+foo "bar" bla|foo|bar|bla|
+"foo" "bar" "bla"|foo|bar|bla|
+"foo" bar "bla"|foo|bar|bla|
+"foo" bar bla|foo|bar|bla|
+foo 'bar' bla|foo|bar|bla|
+'foo' 'bar' 'bla'|foo|bar|bla|
+'foo' bar 'bla'|foo|bar|bla|
+'foo' bar bla|foo|bar|bla|
+blurb foo"bar"bar"fasel" baz|blurb|foobarbarfasel|baz|
+blurb foo'bar'bar'fasel' baz|blurb|foobarbarfasel|baz|
+""||
+''||
+\"|"|
+"\""|"|
+"foo\ bar"|foo\ bar|
+"foo\\ bar"|foo\ bar|
+"foo\\ bar\""|foo\ bar"|
+"foo\\" bar\"|foo\|bar"|
+"foo\\ bar\" dfadf"|foo\ bar" dfadf|
+"foo\\\ bar\" dfadf"|foo\\ bar" dfadf|
+"foo\\\x bar\" dfadf"|foo\\x bar" dfadf|
+"foo\x bar\" dfadf"|foo\x bar" dfadf|
+\'|'|
+'foo\ bar'|foo\ bar|
+'foo\\ bar'|foo\\ bar|
+"foo\\\x bar\" df'a\ 'df"|foo\\x bar" df'a\ 'df|
+\"foo|"foo|
+\"foo\x|"foox|
+"foo\x"|foo\x|
+"foo\ "|foo\ |
+foo\ xx|foo xx|
+foo\ x\x|foo xx|
+foo\ x\x\"|foo xx"|
+"foo\ x\x"|foo\ x\x|
+"foo\ x\x\\"|foo\ x\x\|
+"foo\ x\x\\""foobar"|foo\ x\x\foobar|
+"foo\ x\x\\"\'"foobar"|foo\ x\x\'foobar|
+"foo\ x\x\\"\'"fo'obar"|foo\ x\x\'fo'obar|
+"foo\ x\x\\"\'"fo'obar" 'don'\''t'|foo\ x\x\'fo'obar|don't|
+"foo\ x\x\\"\'"fo'obar" 'don'\''t' \\|foo\ x\x\'fo'obar|don't|\|
+'foo\ bar'|foo\ bar|
+'foo\\ bar'|foo\\ bar|
+foo\ bar|foo bar|
+foo#bar\nbaz|foo|baz|
+:-) ;-)|:-)|;-)|
+áéíóú|áéíóú|
+]]
+
+-- broken data are test cases, works well in CPython shlex, but do not in Lua version
+local broken_data = [[
+foo "" bar|foo||bar|
+foo '' bar|foo||bar|
+foo "" "" "" bar|foo||||bar|
+foo '' '' '' bar|foo||||bar|
+]]
+
+local function splitlines(str, sep)
+  if sep == nil then
+    sep = "\r?\n"
+  end
+  local pos = 0
+  return function()
+    if pos >= #str then return nil end
+    local s, e = str:find(sep, pos)
+    local line = str:sub(pos, s and s - 1)
+    pos = (e or #str) + 1
+    return line
+  end
+end
+
+local function split(str, sep)
+  local t = {}
+  for part in splitlines(str, sep) do
+    table.insert(t, part)
+  end
+  return t
+end
+
+-- reimplementation of test_shlex.py setUp code
+-- https://github.com/python/cpython/blob/962304a54ca79da0838cf46dd4fb744045167cdd/Lib/test/test_shlex.py#L141
+local function test_cases(str)
+  local it = splitlines(str)
+  return function()
+    local line = it()
+    if line == nil then return nil end
+    local expected = split(line, "|")
+    local input = expected[1]
+    input = input:gsub("\\n", "\n")
+    table.remove(expected, 1)
+    return input, expected
+  end
+end
+
+describe("posix", function()
+  for input, expected in test_cases(posix_data) do
+    it("'" .. input .. "'", function()
+      local actual = SHLEX.split(input)
+      assert.same(expected, actual)
+    end)
+  end
+end)
+
+describe("curl", function()
+  it("should return url as one string", function()
+    local input = "curl http://example.com"
+    local actual = SHLEX.split(input)
+    local expected = { "curl", "http://example.com" }
+    assert.same(expected, actual)
+  end)
+end)
+
+describe("broken", function()
+  for input, expected in test_cases(broken_data) do
+    it("'" .. input .. "'", function()
+      local shlex = SHLEX.shlex:create(input, true, nil)
+      shlex.debug = 0
+      shlex.whitespace_split = true
+      local actual = shlex:list()
+      assert.is_not.same(expected, actual)
+    end)
+  end
+end)


### PR DESCRIPTION
And more close to Python original. Now it supports like `curl
https://example.com` (without quotes), or ` curl 'https://example.com'`
(with a space at the start).

1. Add a test data from CPython test_shlex.py
2. Reimplement Python code generating a test cases.
3. Mark a few tests as broken and move to separate test case - probably
   not worth fixing.
4. Add a fix for curl case - set whitespace_fix to true, this is what
   Python shlex.split does.
5. Avoid `goto continue` by introducing a continue boolean flag in a
   parsing code. Resulting code is ugly, but it works.
