### PR TITLE
fix(ui): treesitter foldexpr calculate not work

### DIFF
--- a/lua/kulala/ui/init.lua
+++ b/lua/kulala/ui/init.lua
@@ -108,13 +108,14 @@ vim.api.nvim_create_autocmd("WinClosed", {
 local function set_buffer_contents(contents, ft)
   if buffer_exists() then
     local buf = replace_buffer()
-    local lines = vim.split(contents, "\n")
-    vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+    -- setup filetype first so that treesitter foldexpr can calculate fold level per lines
     if ft ~= nil then
       vim.bo[buf].filetype = ft
     else
       vim.bo[buf].filetype = "text"
     end
+    local lines = vim.split(contents, "\n")
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
   end
 end
 


### PR DESCRIPTION
When setup
``` lua
vim.opt.foldmethod = 'expr'
vim.opt.foldexpr = 'v:lua.vim.treesitter.foldexpr()'
```
the fold level per lines not getting correct result, this means that `zc` `zo` will not work in result buffer. this commit fix it. 
Related #128