### PR TITLE
fix: resolve "no such file or directory" error in scratchpad

### DIFF
--- a/lua/kulala/globals/init.lua
+++ b/lua/kulala/globals/init.lua
@@ -4,7 +4,7 @@ local M = {}
 
 local plugin_tmp_dir = FS.get_plugin_tmp_dir()
 
-M.VERSION = "4.0.0"
+M.VERSION = "4.0.1"
 M.UI_ID = "kulala://ui"
 M.SCRATCHPAD_ID = "kulala://scratchpad"
 M.HEADERS_FILE = plugin_tmp_dir .. "/headers.txt"

--- a/lua/kulala/parser/scripts/engines/javascript/init.lua
+++ b/lua/kulala/parser/scripts/engines/javascript/init.lua
@@ -50,19 +50,20 @@ local generate_one = function(script_type, is_external_file, script_data)
     return nil, nil
   end
   local script_cwd
+  -- buf_dir is "kulala:" when the buffer is scratch buffer
+  -- in this case, use current working directory for script_cwd and base_dir
+  local buf_dir = FS.get_current_buffer_dir()
 
   if is_external_file then
     -- if script_data starts with ./ or ../, it is a relative path
     if string.match(script_data, "^%./") or string.match(script_data, "^%../") then
       local local_script_path = script_data:gsub("^%./", "")
-      script_data = FS.join_paths(FS.get_current_buffer_dir(), local_script_path)
+      local base_dir = buf_dir == "kulala:" and vim.loop.cwd() or buf_dir
+      script_data = FS.join_paths(base_dir, local_script_path)
     end
-    script_cwd = FS.get_dir_by_filepath(script_data)
+    script_cwd = buf_dir == "kulala:" and vim.loop.cwd() or FS.get_dir_by_filepath(script_data)
     userscript = FS.read_file(script_data)
   else
-    local buf_dir = FS.get_current_buffer_dir()
-    -- buf_dir is "kulala:" when the buffer is scratch buffer
-    -- in this case, use current working directory
     script_cwd = buf_dir == "kulala:" and vim.loop.cwd() or buf_dir
     userscript = vim.fn.join(script_data, "\n")
   end

--- a/lua/kulala/parser/scripts/engines/javascript/init.lua
+++ b/lua/kulala/parser/scripts/engines/javascript/init.lua
@@ -113,14 +113,20 @@ M.run = function(type, data)
   end
 
   for _, script in ipairs(scripts) do
+    local cwd = script.cwd
+
+    if cwd == "kulala:" then
+      cwd = FS.get_plugin_tmp_dir()
+    end
+
     local output = vim
       .system({
         "node",
         script.path,
       }, {
-        cwd = script.cwd,
+        cwd = cwd,
         env = {
-          NODE_PATH = FS.join_paths(script.cwd, "node_modules"),
+          NODE_PATH = FS.join_paths(cwd, "node_modules"),
         },
       })
       :wait()


### PR DESCRIPTION
Close #253 

After a little investigation, I thought it might be due to the value of `script.cwd` being `kulala:` when started with scratchpad.
So I modified it to use the tmp_dir path instead if the value is `kulala:`.

