### PR TITLE
feat(headers): use as supplied + support multiple headers

### DIFF
--- a/lua/kulala/cmd/init.lua
+++ b/lua/kulala/cmd/init.lua
@@ -123,7 +123,12 @@ M.run_parser = function(req, callback)
           end
         end
         INT_PROCESSING.redirect_response_body_to_file(result.redirect_response_body_to_files)
-        PARSER.scripts.javascript.run("post_request", result.scripts.post_request)
+
+        local has_post_request_scripts = #result.scripts.post_request.inline > 0
+          or #result.scripts.pre_request.files > 0
+        if has_post_request_scripts then
+          PARSER.scripts.javascript.run("post_request", result.scripts.post_request)
+        end
         Api.trigger("after_request")
       end
       Fs.delete_request_scripts_files()

--- a/lua/kulala/globals/init.lua
+++ b/lua/kulala/globals/init.lua
@@ -4,7 +4,7 @@ local M = {}
 
 local plugin_tmp_dir = FS.get_plugin_tmp_dir()
 
-M.VERSION = "4.0.2"
+M.VERSION = "4.0.3"
 M.UI_ID = "kulala://ui"
 M.SCRATCHPAD_ID = "kulala://scratchpad"
 M.HEADERS_FILE = plugin_tmp_dir .. "/headers.txt"

--- a/lua/kulala/internal_processing/init.lua
+++ b/lua/kulala/internal_processing/init.lua
@@ -18,18 +18,39 @@ local function get_nested_value(t, key)
   return value
 end
 
-local get_headers_as_table = function()
+---Function to get the last headers as a table
+---@description Reads the headers file and returns the headers as a table.
+---In some cases the headers file might contain multiple header sections,
+---e.g. if you have follow-redirections enabled.
+---This function will return the headers of the last response.
+---@return table
+local get_last_headers_as_table = function()
   local headers_file = FS.read_file(GLOBALS.HEADERS_FILE):gsub("\r\n", "\n")
   local lines = vim.split(headers_file, "\n")
   local headers_table = {}
+  -- INFO:
+  -- We only want the headers of the last response
+  -- so we reset the headers_table only each time the previous line was empty
+  -- and we also have new headers data
+  local previously_empty = false
   for _, header in ipairs(lines) do
-    if header:find(":") ~= nil then
-      local kv = vim.split(header, ":")
-      local key = kv[1]
-      -- the value should be everything after the first colon
-      -- but we can't use slice and join because the value might contain colons
-      local value = header:sub(#key + 2)
-      headers_table[key] = vim.trim(value)
+    local empty_line = header == ""
+    if empty_line then
+      previously_empty = true
+    else
+      if previously_empty then
+        headers_table = {}
+      end
+      previously_empty = false
+      if header:find(":") ~= nil then
+        local kv = vim.split(header, ":")
+        local key = kv[1]
+        -- INFO:
+        -- the value should be everything after the first colon
+        -- but we can't use slice and join because the value might contain colons
+        local value = header:sub(#key + 2)
+        headers_table[key] = vim.trim(value)
+      end
     end
   end
   return headers_table
@@ -78,7 +99,7 @@ local get_cookies_as_table = function()
 end
 
 local get_lower_headers_as_table = function()
-  local headers = get_headers_as_table()
+  local headers = get_last_headers_as_table()
   local headers_table = {}
   for key, value in pairs(headers) do
     headers_table[key:lower()] = value
@@ -101,7 +122,7 @@ end
 M.set_env_for_named_request = function(name, body)
   local named_request = {
     response = {
-      headers = get_headers_as_table(),
+      headers = get_last_headers_as_table(),
       body = body,
       cookies = get_cookies_as_table(),
     },

--- a/lua/kulala/parser/utils.lua
+++ b/lua/kulala/parser/utils.lua
@@ -1,21 +1,117 @@
 local M = {}
 
+-- PERF: we do a lot of if else blocks with repeating loops
+-- we could "optimize" this by using a single loop and if else blocks
+-- that would make the code more readable and easier to maintain
+-- but it would also make it slower
+
+---Check if a request has a specific meta tag
+---@param request table The request to check
+---@param tag string The meta tag to check for
 M.contains_meta_tag = function(request, tag)
+  tag = tag:lower()
   for _, meta in ipairs(request.metadata) do
-    if meta.name == tag then
+    if meta.name:lower() == tag then
       return true
     end
   end
   return false
 end
 
+---Check if a header is present in the request
+---@param headers table The headers to check
+---@param header string The header name to check
+---@param value string|nil The value to check for or nil if only the header name should be checked
+---@return boolean
 M.contains_header = function(headers, header, value)
-  for k, v in pairs(headers) do
-    if k == header and v == value then
-      return true
+  header = header:lower()
+  value = value and value:lower() or nil
+  vim.print("header: " .. header .. " value: " .. value)
+  if value == nil then
+    for k, _ in pairs(headers) do
+      if k:lower() == header then
+        return true
+      end
+    end
+  else
+    for k, v in pairs(headers) do
+      if k:lower() == header and v:lower() == value then
+        return true
+      end
     end
   end
   return false
+end
+
+---Get the value of a header from the request
+---@param headers table The headers to check
+---@param header string The header name to check
+---@param dont_ignore_case boolean|nil If true, the header name will be case sensitive
+---@return string|nil
+M.get_header_value = function(headers, header, dont_ignore_case)
+  header = dont_ignore_case and header or header:lower()
+  for k, v in pairs(headers) do
+    if k == header then
+      return v
+    end
+  end
+  return nil
+end
+
+---Get the name of a header from the request
+---@param headers table The headers to check
+---@param header string The header name to check
+---@param dont_ignore_case boolean|nil If true, the header name will be case sensitive
+---@return string|nil
+M.get_header_name = function(headers, header, dont_ignore_case)
+  header = dont_ignore_case and header or header:lower()
+  for k, _ in pairs(headers) do
+    if k:lower() == header then
+      return k
+    end
+  end
+  return nil
+end
+
+---Get a header from the request
+---@param headers table The headers to check
+---@param header string The header name to check
+---@param value string|nil The value to check for or nil if only the header name should be checked
+---@param dont_ignore_case boolean|nil If true, the header name will be case sensitive
+---@return (string|nil), (string|nil) The header name and value or nil if not found
+M.get_header = function(headers, header, value, dont_ignore_case)
+  header = dont_ignore_case and header or header:lower()
+  value = value and (dont_ignore_case and value or value:lower()) or nil
+  if dont_ignore_case then
+    if value == nil then
+      for k, _ in pairs(headers) do
+        if k == header then
+          return k, headers[k]
+        end
+      end
+    else
+      for k, v in pairs(headers) do
+        if k == header and v == value then
+          return k, v
+        end
+      end
+    end
+  else
+    if value == nil then
+      for k, _ in pairs(headers) do
+        if k:lower() == header then
+          return k, headers[k]
+        end
+      end
+    else
+      for k, v in pairs(headers) do
+        if k:lower() == header and v:lower() == value then
+          return k, v
+        end
+      end
+    end
+  end
+  return nil, nil
 end
 
 return M


### PR DESCRIPTION
- Use headers with casing as supplied in the request (don't lowercase them permanently).
- Also only use last headers from request in content type detection
- Only run post-request scripts if there are any
- make contains utils case-insensitive by default