### PR TITLE
test(ui): add tests for from_curl() and close()

### DIFF
--- a/lua/kulala/ui/init.lua
+++ b/lua/kulala/ui/init.lua
@@ -83,16 +83,13 @@ local open_buffer = function()
   vim.api.nvim_set_current_win(prev_win)
 end
 
-M._close_buffer = function()
+local close_buffer = function()
   vim.cmd("bdelete! " .. GLOBALS.UI_ID)
 end
 
-M._buffer_exists = function()
+local buffer_exists = function()
   return get_buffer() ~= nil
 end
-
-local close_buffer = M._close_buffer
-local buffer_exists = M._buffer_exists
 
 -- Create an autocmd to delete the buffer when the window is closed
 -- This is necessary to prevent the buffer from being left behind
@@ -271,8 +268,8 @@ M.open_all = function()
 end
 
 M.close = function()
-  if M._buffer_exists() then
-    M._close_buffer()
+  if buffer_exists() then
+    close_buffer()
   end
   local ext = vim.fn.expand("%:e")
   if ext == "http" or ext == "rest" then

--- a/lua/kulala/ui/init.lua
+++ b/lua/kulala/ui/init.lua
@@ -83,13 +83,16 @@ local open_buffer = function()
   vim.api.nvim_set_current_win(prev_win)
 end
 
-local close_buffer = function()
+M._close_buffer = function()
   vim.cmd("bdelete! " .. GLOBALS.UI_ID)
 end
 
-local function buffer_exists()
+M._buffer_exists = function()
   return get_buffer() ~= nil
 end
+
+local close_buffer = M._close_buffer
+local buffer_exists = M._buffer_exists
 
 -- Create an autocmd to delete the buffer when the window is closed
 -- This is necessary to prevent the buffer from being left behind
@@ -268,8 +271,8 @@ M.open_all = function()
 end
 
 M.close = function()
-  if buffer_exists() then
-    close_buffer()
+  if M._buffer_exists() then
+    M._close_buffer()
   end
   local ext = vim.fn.expand("%:e")
   if ext == "http" or ext == "rest" then

--- a/tests/test_helper/ui.lua
+++ b/tests/test_helper/ui.lua
@@ -1,0 +1,55 @@
+local api = vim.api
+
+local UITestHelper = {}
+
+UITestHelper.delete_all_bufs = function()
+  -- Get a list of all buffer numbers
+  local buffers = vim.api.nvim_list_bufs()
+
+  -- Iterate over each buffer and delete it
+  for _, buf in ipairs(buffers) do
+    -- Check if the buffer is valid and loaded
+    if vim.api.nvim_buf_is_loaded(buf) then
+      vim.api.nvim_buf_delete(buf, {})
+    end
+  end
+end
+
+---@param lines? string[]
+---@param bufname? string
+---@return integer bufnr
+UITestHelper.create_buf = function(lines, bufname)
+  lines = lines or {}
+  local bufnr = vim.api.nvim_create_buf(true, true)
+  api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+  api.nvim_set_current_buf(bufnr)
+  api.nvim_win_set_cursor(0, { 1, 1 })
+
+  if bufname then
+    vim.api.nvim_buf_set_name(bufnr, bufname)
+  end
+
+  return bufnr
+end
+
+---@param bufnr integer
+---@return string[] lines
+UITestHelper.get_buf_lines = function(bufnr)
+  return vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+end
+
+---@return integer[] bufnr list
+UITestHelper.list_loaded_bufs = function()
+  local bufnr_list = vim.api.nvim_list_bufs()
+
+  local loaded_bufs = {}
+  for _, bufnr in ipairs(bufnr_list) do
+    if vim.api.nvim_buf_is_loaded(bufnr) then
+      loaded_bufs[#loaded_bufs + 1] = bufnr
+    end
+  end
+
+  return loaded_bufs
+end
+
+return UITestHelper

--- a/tests/ui/init_spec.lua
+++ b/tests/ui/init_spec.lua
@@ -38,7 +38,7 @@ describe("kulala.ui", function()
     local extensions = { "http", "rest" }
     for _, ext in ipairs(extensions) do
       it(("closes ui and %s file"):format(ext), function()
-        ui_helper.create_buf({ "" }, "kulala://ui")
+        ui_helper.create_buf({ "" }, GLOBALS.UI_ID)
         ui_helper.create_buf({ "" }, "file_for_requests." .. ext)
 
         UI.close()
@@ -47,7 +47,7 @@ describe("kulala.ui", function()
         for _, bufnr in ipairs(loaded_bufs) do
           local bufname = vim.api.nvim_buf_get_name(bufnr)
 
-          assert.is.True(bufname:find("kulala://ui") == nil, "should have closed the ui")
+          assert.is.True(bufname:find(GLOBALS.UI_ID) == nil, "should have closed the ui")
           assert.is.True(
             bufname:find("file_for_requests." .. ext) == nil,
             "should have closed the file with extension: " .. ext

--- a/tests/ui/init_spec.lua
+++ b/tests/ui/init_spec.lua
@@ -1,12 +1,7 @@
-local CONFIG = require("kulala.config")
-local FORMATTER = require("kulala.formatter")
-local FS = require('kulala.globals')
-local GLOBALS = require('kulala.globals')
-local INT_PROCESSING = require("kulala.internal_processing")
-local WINBAR = require("kulala.ui.winbar")
-local UI = require('kulala.ui')
+local GLOBALS = require("kulala.globals")
+local UI = require("kulala.ui")
 
-local assert = require('luassert')
+local assert = require("luassert")
 
 describe("kulala.ui", function()
   -- restore all changed done by luassert before each test run
@@ -53,7 +48,7 @@ describe("kulala.ui", function()
   end)
 
   it("from_curl", function()
-    local getreg = stub(vim.fn, 'getreg', function()
+    local getreg = stub(vim.fn, "getreg", function()
       return "curl http://example.com"
     end)
     local nvim_put = stub(vim.api, 'nvim_put')

--- a/tests/ui/init_spec.lua
+++ b/tests/ui/init_spec.lua
@@ -1,0 +1,90 @@
+local CONFIG = require("kulala.config")
+local FORMATTER = require("kulala.formatter")
+local FS = require('kulala.globals')
+local GLOBALS = require('kulala.globals')
+local INT_PROCESSING = require("kulala.internal_processing")
+local WINBAR = require("kulala.ui.winbar")
+local UI = require('kulala.ui')
+
+local assert = require('luassert')
+
+describe("kulala.ui", function()
+  -- restore all changed done by luassert before each test run
+  local snapshot
+
+  before_each(function()
+    snapshot = assert:snapshot()
+  end)
+
+  after_each(function()
+    snapshot:revert()
+  end)
+
+  it("_buffer_exists", function()
+    local nvim_list_bufs = stub(vim.api, "nvim_list_bufs", function()
+      return { 1, 2 }
+    end)
+    local nvim_buf_get_name = stub(vim.api, "nvim_buf_get_name", function(bufnr)
+      if bufnr == 2 then
+        return GLOBALS.UI_ID
+      end
+    end)
+
+    local exist = UI._buffer_exists()
+    assert.is_true(exist)
+    assert.stub(nvim_list_bufs).was.called(1)
+    assert.stub(nvim_buf_get_name).was.called_with(1)
+    assert.stub(nvim_buf_get_name).was.called_with(2)
+  end)
+
+  it("_buffer_not_exists", function()
+    local nvim_list_bufs = stub(vim.api, "nvim_list_bufs", function()
+      return { 1, 2 }
+    end)
+    local nvim_buf_get_name = stub(vim.api, "nvim_buf_get_name", function()
+      return nil
+    end)
+
+    local exist = UI._buffer_exists()
+    assert.is_false(exist)
+    assert.stub(nvim_list_bufs).was.called(1)
+    assert.stub(nvim_buf_get_name).was.called_with(1)
+    assert.stub(nvim_buf_get_name).was.called_with(2)
+  end)
+
+  it("from_curl", function()
+    local getreg = stub(vim.fn, 'getreg', function()
+      return "curl http://example.com"
+    end)
+    local nvim_put = stub(vim.api, 'nvim_put')
+
+    UI.from_curl()
+
+    assert.stub(getreg).was.called_with("+")
+    local expected = {
+      [[# curl http://example.com]],
+      [[GET http://example.com]],
+      "",
+    }
+    assert.stub(nvim_put).was.called_with(expected, "l", false, false)
+  end)
+
+  it("close", function()
+    local buffer_exists = stub(UI, "_buffer_exists", function()
+      return true
+    end)
+    local close_buffer = stub(UI, "_close_buffer")
+    local expand = stub(vim.fn, "expand", function()
+      return "http"
+    end)
+    local cmd = stub(vim, "cmd")
+
+    UI.close()
+
+    assert.stub(buffer_exists).was.called(1)
+    assert.stub(close_buffer).was.called(1)
+    assert.stub(expand).was.called(1)
+    assert.stub(expand).was.called_with("%:e")
+    assert.stub(cmd).was.called_with("bdelete")
+  end)
+end)

--- a/tests/ui/init_spec.lua
+++ b/tests/ui/init_spec.lua
@@ -51,7 +51,7 @@ describe("kulala.ui", function()
     local getreg = stub(vim.fn, "getreg", function()
       return "curl http://example.com"
     end)
-    local nvim_put = stub(vim.api, 'nvim_put')
+    local nvim_put = stub(vim.api, "nvim_put")
 
     UI.from_curl()
 


### PR DESCRIPTION
Continuation of #240 

This PR contains tests for:
* from_curl()
* close()

My intention is to continue adding tests, but on different PRs. I tried to avoid having loads of API calls on written on the tests buy using a test helper.