### PR TITLE
docs: add stats to available winbar panes

### DIFF
--- a/docs/docs/getting-started/configuration-options.md
+++ b/docs/docs/getting-started/configuration-options.md
@@ -87,7 +87,7 @@ the Kulala plugin with the available `opts`:
     winbar = false,
 
     -- Specify the panes to be displayed by default
-    -- Current avaliable pane contains { "body", "headers", "headers_body", "script_output" },
+    -- Current avaliable pane contains { "body", "headers", "headers_body", "script_output", "stats" },
     default_winbar_panes = { "body", "headers", "headers_body" },
 
     -- enable reading vscode rest client environment variables
@@ -157,6 +157,7 @@ Possible values:
 - `headers`
 - `headers_body`
 - `script_output`
+- `stats`
 
 Default: `body`
 

--- a/lua/kulala/config/init.lua
+++ b/lua/kulala/config/init.lua
@@ -63,7 +63,7 @@ M.defaults = {
   -- enable winbar
   winbar = false,
   -- Specify the panes to be displayed by default
-  -- Current avaliable pane contains { "body", "headers", "headers_body", "script_output" },
+  -- Current avaliable pane contains { "body", "headers", "headers_body", "script_output", "stats" },
   default_winbar_panes = { "body", "headers", "headers_body" },
   -- enable reading vscode rest client environment variables
   vscode_rest_client_environmentvars = false,


### PR DESCRIPTION
I have updated the document to reflect that `stats` can be configured as a view or a winbar pane.
