### PR TITLE
feat: set buftype of scratchpad to nofile

### DIFF
--- a/lua/kulala/ui/init.lua
+++ b/lua/kulala/ui/init.lua
@@ -447,6 +447,7 @@ M.scratchpad = function()
   vim.cmd("e " .. GLOBALS.SCRATCHPAD_ID)
   vim.cmd("setlocal noswapfile")
   vim.cmd("setlocal filetype=http")
+  vim.cmd("setlocal buftype=nofile")
   vim.api.nvim_buf_set_lines(0, 0, -1, false, CONFIG.get().scratchpad_default_contents)
 end
 


### PR DESCRIPTION
Currently, if you try to quit vim after opening a scratchpad, you'll either get an error or be prompted to save.
Since scratchpads aren't meant to be saved, this behavior is weird.
This PR fixes the issue.
