### PR TITLE
fix(parser): handle very large bodies

### DIFF
--- a/lua/kulala/parser/init.lua
+++ b/lua/kulala/parser/init.lua
@@ -711,8 +711,13 @@ M.parse = function(start_request_linenr)
         Logger.error("Failed to create a temporary file for the binary request body")
       end
     else
-      table.insert(res.cmd, "--data")
-      table.insert(res.cmd, res.body)
+      local tmp_file = FS.get_text_temp_file(res.body)
+      if tmp_file ~= nil then
+        table.insert(res.cmd, "--data")
+        table.insert(res.cmd, "@" .. tmp_file)
+      else
+        Logger.error("Failed to create a temporary file for the request body")
+      end
     end
   else -- no content type supplied
     -- check if we are a graphql query

--- a/lua/kulala/utils/fs.lua
+++ b/lua/kulala/utils/fs.lua
@@ -355,6 +355,17 @@ M.get_binary_temp_file = function(content)
   return tmp_file
 end
 
+M.get_text_temp_file = function(content)
+  local tmp_file = vim.fn.tempname()
+  local f = io.open(tmp_file, "w")
+  if f == nil then
+    return nil
+  end
+  f:write(content)
+  f:close()
+  return tmp_file
+end
+
 ---Read file lines
 ---@param filename string
 ---@return string[]


### PR DESCRIPTION
If you try to create a request with a large body the following error occurs.

```
Error executing vim.schedule lua callback: Vim:E903: Process failed to start: argument list
 too long: "/usr/bin/curl"                                                                 
stack traceback:                                                                           
        [C]: in function 'jobstart'                                                        
        ...ocal/share/nvim/lazy/kulala.nvim/lua/kulala/cmd/init.lua:88: in function 'run_pa
rser'                                                                                      
        ...local/share/nvim/lazy/kulala.nvim/lua/kulala/ui/init.lua:205: in function <...lo
cal/share/nvim/lazy/kulala.nvim/lua/kulala/ui/init.lua:194> 
```

This looks like it is due to a shell limitation.
This fix write the body to a temporary file and passed that to curl.
