### PR TITLE
fix(treesitter): show body on treesitter inspect

### DIFF
--- a/lua/kulala/parser/treesitter.lua
+++ b/lua/kulala/parser/treesitter.lua
@@ -63,6 +63,7 @@ local REQUEST_VISITORS = {
     req.method = fields.method
     req.http_version = fields.http_version
     req.body = fields.body
+    req.body_display = fields.body
     req.start_line = start_line
     req.block_line_count = end_line - start_line
     req.lines_length = end_line - start_line


### PR DESCRIPTION
`require("kulala").inspect()` with `treesitter = true` does not display the body, this PR should address that.