### PR TITLE
feat(parser): huge req bodies + don't assume blobs

### DIFF
--- a/docs/docs/usage/huge-request-body.md
+++ b/docs/docs/usage/huge-request-body.md
@@ -1,0 +1,36 @@
+# Huge Request Body
+
+If you try to create a request with a large body,
+
+an error might occur due to a shell limitation of arg list size.
+
+To avoid this error, you can use the `@write-body-to-temporary-file`
+meta tag in the request section.
+
+This tells Kulala to write the request body to a
+temporary file and use the file as the request body.
+
+:::note
+
+For `Content-Type: multipart/form-data` this isn't not necessary,
+because Kulala enforces the use of temporary files for this content type.
+
+:::
+
+```http title="huge-request-body.http"
+
+# @write-body-to-temporary-file
+POST https://httpbin.org/post HTTP/1.1
+Content-Type: application/json
+Accept: application/json
+
+{
+  "name": "John",
+  "age": 30,
+  "address": "123 Main St, Springfield, IL 62701",
+  "phone": "555-555-5555",
+  "email": ""
+}
+```
+
+In the example above, the request body is written to a temporary file.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -30,6 +30,7 @@ const sidebars: SidebarsConfig = {
       items: [
         "usage/public-methods",
         "usage/api",
+        "usage/huge-request-body",
         "usage/authentication",
         "usage/automatic-response-formatting",
         "usage/dotenv-and-http-client.env.json-support",

--- a/lua/kulala/utils/fs.lua
+++ b/lua/kulala/utils/fs.lua
@@ -312,22 +312,6 @@ M.get_plugin_path = function(paths)
   return M.get_plugin_root_dir() .. M.ps .. table.concat(paths, M.ps)
 end
 
----Check if a string is a blob
----@param s string
----@return boolean
-M.is_blob = function(s)
-  -- Loop through each character in the string
-  for i = 1, #s do
-    local byte = s:byte(i)
-    -- Check if the byte is outside the printable ASCII range (32-126)
-    -- Allow tab (9), newline (10), and carriage return (13) as exceptions
-    if (byte < 32 or byte > 126) and byte ~= 9 and byte ~= 10 and byte ~= 13 then
-      return true -- If any non-printable character is found, it's likely a blob
-    end
-  end
-  return false -- If no non-printable characters are found, it's not a blob
-end
-
 ---Read a file
 ---@param filename string
 ---@param is_binary boolean|nil
@@ -342,6 +326,17 @@ M.read_file = function(filename, is_binary)
   local content = f:read("*a")
   f:close()
   return content
+end
+
+M.get_temp_file = function(content)
+  local tmp_file = vim.fn.tempname()
+  local f = io.open(tmp_file, "w")
+  if f == nil then
+    return nil
+  end
+  f:write(content)
+  f:close()
+  return tmp_file
 end
 
 M.get_binary_temp_file = function(content)


### PR DESCRIPTION
Metatag flag for huge / large request bodies as shown in #299:

```http
# @write-body-to-temporary-file
POST https://httpbin.org/post HTTP/1.1
Content-Type: application/x-www-form-urlencoded
Accept: application/json

name={{name}}&
age={{age}}
```

this is autmmatically enforce for multipart/form-data content types.

---

Remove assumptions on what is a blob or what is not. This closes #298 