### PR TITLE
revert(quickfix): folds not working in lazyvim

### DIFF
--- a/lua/kulala/ui/init.lua
+++ b/lua/kulala/ui/init.lua
@@ -52,7 +52,7 @@ local replace_buffer = function()
   local old_bufnr = get_buffer()
 
   local new_bufnr = vim.api.nvim_create_buf(true, false)
-  vim.bo[new_bufnr].swapfile = false
+  vim.bo[new_bufnr].buftype = "nofile"
 
   if old_bufnr ~= nil then
     for _, win in ipairs(vim.fn.win_findbuf(old_bufnr)) do
@@ -78,7 +78,6 @@ local open_buffer = function()
   if CONFIG.get().winbar then
     WINBAR.create_winbar(get_win())
   end
-  vim.bo[get_buffer()].modified = false
   vim.api.nvim_set_current_win(prev_win)
 end
 
@@ -116,7 +115,6 @@ local function set_buffer_contents(contents, ft)
     end
     local lines = vim.split(contents, "\n")
     vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
-    vim.bo[buf].modified = false
   end
 end
 
@@ -445,7 +443,6 @@ end
 
 M.scratchpad = function()
   vim.cmd("e " .. GLOBALS.SCRATCHPAD_ID)
-  vim.cmd("setlocal noswapfile")
   vim.cmd("setlocal filetype=http")
   vim.api.nvim_buf_set_lines(0, 0, -1, false, CONFIG.get().scratchpad_default_contents)
 end


### PR DESCRIPTION
This reverts these quickfix commits:

https://github.com/mistweaverco/kulala.nvim/pull/279 https://github.com/mistweaverco/kulala.nvim/pull/286