### PR TITLE
Use the correct body for GraphQL requests

### DIFF
--- a/lua/kulala/parser/init.lua
+++ b/lua/kulala/parser/init.lua
@@ -689,7 +689,7 @@ M.parse = function(start_request_linenr)
       local gql_json = GRAPHQL_PARSER.get_json(res.body)
       if gql_json then
         if PARSER_UTILS.contains_meta_tag(res, "write-body-to-temporary-file") then
-          local tmp_file = FS.get_temp_file(res.body)
+          local tmp_file = FS.get_temp_file(gql_json)
           if tmp_file ~= nil then
             table.insert(res.cmd, "--data")
             table.insert(res.cmd, "@" .. tmp_file)
@@ -730,7 +730,7 @@ M.parse = function(start_request_linenr)
     if is_graphql then
       local gql_json = GRAPHQL_PARSER.get_json(res.body)
       if gql_json then
-        local tmp_file = FS.get_temp_file(res.body)
+        local tmp_file = FS.get_temp_file(gql_json)
         if tmp_file ~= nil then
           table.insert(res.cmd, "--data")
           table.insert(res.cmd, "@" .. tmp_file)


### PR DESCRIPTION
After a period of not needing to use kulala, I recently updated it and went to use my saved GraphQL requests. However, I found that none of them were working, because kulala was sending the raw body of the request file, rather than properly parsing it to JSON and sending that blob.

After a bunch of digging, I figured out that bc2eb2d789bf2fe72e1d868c63a522e1c6733edf was the culprit. Specifically, [here](https://github.com/mistweaverco/kulala.nvim/commit/bc2eb2d789bf2fe72e1d868c63a522e1c6733edf#diff-6d98ccc7bb245892121a4c9e28c45f3b507f0610ff34e0ca4d177f84baa71c37L702) and [here](https://github.com/mistweaverco/kulala.nvim/commit/bc2eb2d789bf2fe72e1d868c63a522e1c6733edf#diff-6d98ccc7bb245892121a4c9e28c45f3b507f0610ff34e0ca4d177f84baa71c37L715) changed `gql_json` to `res.body`.

This just switches those lines to use `gql_json` again, which fixed all my broken GraphQL requests.