### PR TITLE
fix: don't start request timer until after prompt responses are submitted

### DIFF
--- a/lua/kulala/cmd/init.lua
+++ b/lua/kulala/cmd/init.lua
@@ -85,6 +85,7 @@ M.run_parser = function(req, callback)
     return
   end
   local result = req.cmd ~= nil and req or PARSER.parse(req.start_line)
+  local start = vim.loop.hrtime()
   vim.fn.jobstart(result.cmd, {
     on_stderr = function(_, datalist)
       if callback then
@@ -133,7 +134,7 @@ M.run_parser = function(req, callback)
       end
       Fs.delete_request_scripts_files()
       if callback then
-        callback(success)
+        callback(success, start)
       end
     end,
   })

--- a/lua/kulala/ui/init.lua
+++ b/lua/kulala/ui/init.lua
@@ -217,7 +217,6 @@ end
 M.open = function()
   INLAY.clear()
   vim.schedule(function()
-    local start = vim.loop.hrtime()
     local _, requests = PARSER.get_document()
     local req = PARSER.get_request_at(requests)
     if req == nil then
@@ -227,7 +226,7 @@ M.open = function()
     if req.show_icon_line_number then
       INLAY:show_loading(req.show_icon_line_number)
     end
-    CMD.run_parser(req, function(success)
+    CMD.run_parser(req, function(success, start)
       if not success then
         if req.show_icon_line_number then
           INLAY:show_error(req.show_icon_line_number)


### PR DESCRIPTION
Previously the request's `start` timestamp was set before request parsing, which meant that it was started before the user was prompted for any `@prompt` variables.

**The effect was that the duration the user took to submit the prompt was included in the request duration.**

This PR fixes it by updating the `M.open` to mimic what `M.open_all` already does and receive its `start` timestamp from the `CMD.run_parser` callback.