### PR TITLE
fix(format): fix function format params

### DIFF
--- a/lua/kulala/formatter/init.lua
+++ b/lua/kulala/formatter/init.lua
@@ -2,7 +2,7 @@ local M = {}
 
 M.format = function(formatter, contents)
   if type(formatter) == "function" then
-    return formatter(base_table[method].body)
+    return formatter(contents)
   elseif type(formatter) == "table" then
     local cmd = formatter
     return vim.system(cmd, { stdin = contents, text = true }):wait().stdout

--- a/lua/kulala/ui/init.lua
+++ b/lua/kulala/ui/init.lua
@@ -142,6 +142,15 @@ local function set_buffer_contents(contents, ft)
     end
     local lines = vim.split(contents, "\n")
     vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+
+    -- setup filetype second to trigger filetype autocmd
+    -- first setup's filetype buffer is empty
+    if ft ~= nil then
+      vim.bo[buf].filetype = ft
+    else
+      vim.bo[buf].filetype = "text"
+    end
+
   end
 end
 


### PR DESCRIPTION
1. When setting a custom formatter, an error will be reported for base_table that does not exist.


```
                ["text/tsv"] = {
                    ft = "tsv",
                    formatter = function(body)
                        return body:upper()
                    end,
                },
```

2. When using a custom formatter to process the returned buffer, if the autocmd of filetype is set, the first trigger will be an empty buffer.
