### PR TITLE
feat(api): add `after_next_request`.

### DIFF
--- a/docs/docs/usage/api.md
+++ b/docs/docs/usage/api.md
@@ -3,6 +3,19 @@
 Kulala currently provides one event to hook into,
 but more are planned for the future.
 
+## after_next_request
+
+Triggered after the next request has been successfully completed.
+The queue of callbacks resets after this event is triggered.
+
+```lua
+require('kulala.api').on("after_next_request", function(data)
+  print("Request completed")
+  print("Headers: " .. data.headers)
+  print("Body: " .. data.body)
+end)
+```
+
 ## after_request
 
 Triggered after a request has been successfully completed.

--- a/lua/kulala/api/init.lua
+++ b/lua/kulala/api/init.lua
@@ -4,6 +4,7 @@ local Fs = require("kulala.utils.fs")
 local M = {}
 
 M.events = {
+  ["after_next_request"] = {},
   ["after_request"] = {},
 }
 
@@ -19,6 +20,18 @@ M.trigger = function(name)
   if M.events[name] == nil then
     Logger.error("Invalid event name: " .. name)
     return
+  end
+  if name == "after_next_request" then
+    local headers = Fs.read_file(Globals.HEADERS_FILE)
+    local body = Fs.read_file(Globals.BODY_FILE)
+    for _, callback in ipairs(M.events[name]) do
+      callback({
+        headers = headers,
+        body = body,
+      })
+    end
+    -- reset the queue
+    M.events[name] = {}
   end
   if name == "after_request" then
     local headers = Fs.read_file(Globals.HEADERS_FILE)

--- a/lua/kulala/cmd/init.lua
+++ b/lua/kulala/cmd/init.lua
@@ -139,6 +139,7 @@ M.run_parser = function(req, callback)
         if has_post_request_scripts then
           PARSER.scripts.javascript.run("post_request", result.scripts.post_request)
         end
+        Api.trigger("after_next_request")
         Api.trigger("after_request")
       end
       Fs.delete_request_scripts_files()
@@ -209,6 +210,7 @@ M.run_parser_all = function(doc, callback)
         end
         INT_PROCESSING.redirect_response_body_to_file(result.redirect_response_body_to_files)
         PARSER.scripts.javascript.run("post_request", result.scripts.post_request)
+        Api.trigger("after_next_request")
         Api.trigger("after_request")
       end
       Fs.delete_request_scripts_files()

--- a/lua/kulala/globals/init.lua
+++ b/lua/kulala/globals/init.lua
@@ -4,7 +4,7 @@ local M = {}
 
 local plugin_tmp_dir = FS.get_plugin_tmp_dir()
 
-M.VERSION = "4.6.0"
+M.VERSION = "4.7.0"
 M.UI_ID = "kulala://ui"
 M.SCRATCHPAD_ID = "kulala://scratchpad"
 M.HEADERS_FILE = plugin_tmp_dir .. "/headers.txt"


### PR DESCRIPTION
This triggers only once for the next request and
then flushes the queue.