### PR TITLE
Fix: to allow run_all() for visually selected lines (#325)

### DIFF
--- a/lua/kulala/parser/init.lua
+++ b/lua/kulala/parser/init.lua
@@ -125,7 +125,7 @@ local default_request = {
       files = {},
     },
   },
-  show_icon_line_number = 0,
+  show_icon_line_number = 1,
 }
 
 local function get_current_line_number()
@@ -290,19 +290,21 @@ end
 
 ---Strips invalid characters at the beginning of the line, e.g. comment characters
 local function strip_invalid_chars(tbl)
-  local valid_1 = { "# @", "###", "%%}", "%-%-%-%-%-%-" }
-  local valid_2 = [["%[%]<>{%%}@?%w]]
+  local valid_1 = { "# @", "###", "------" }
+  local valid_2 = [["%[%]<>{%%}@?%w%d]]
 
   return vim
     .iter(tbl)
     :map(function(line)
-      local has_valid_chars = vim.iter(valid_1):any(function(chars)
-        return line:match("^%s*(" .. chars .. ").*$")
+      local has_valid, s
+
+      vim.iter(valid_1):each(function(pattern)
+        s = line:find(pattern, 1, true)
+        line = s and line:sub(s) or line
+        has_valid = s or has_valid
       end)
 
-      if not has_valid_chars then
-        _, line = line:match("^%s*([^" .. valid_2 .. "]*)(.*)$")
-      end
+      line = has_valid and line or line:gsub("^%s*([^" .. valid_2 .. "]*)(.*)$", "%2")
 
       return line
     end)

--- a/tests/functional/ui_spec.lua
+++ b/tests/functional/ui_spec.lua
@@ -143,7 +143,7 @@ describe("requests", function()
       assert.is_same("https://httpbin.org/advanced_1", cmd[#cmd])
     end)
 
-    it("#wip for current selection in in non-http buffer", function()
+    it("for current selection in in non-http buffer", function()
       kulala_config.default_view = "body"
 
       curl.stub({
@@ -157,10 +157,12 @@ describe("requests", function()
           Some text
           Some text
 
+        //###
+
           -- @foobar=bar
           ##@ENV_PROJECT = project_name
 
-          # @accept chunked
+          ;# @accept chunked
           /* POST https://httpbin.org/advanced_1 HTTP/1.1
           #  Content-Type: application/json
 
@@ -180,7 +182,7 @@ describe("requests", function()
         "test.lua"
       )
 
-      h.send_keys("3jV18j")
+      h.send_keys("3jV20j")
 
       kulala.run()
       wait_for_requests(1)


### PR DESCRIPTION
MInor update for #351  to allow `run_allI()` for visual selection.