### PR TITLE
feat(parser): replace variables also in header name

### DIFF
--- a/lua/kulala/parser/init.lua
+++ b/lua/kulala/parser/init.lua
@@ -136,7 +136,8 @@ end
 local function parse_headers(headers, variables, env, silent)
   local h = {}
   for key, value in pairs(headers) do
-    h[key] = StringVariablesParser.parse(value, variables, env, silent)
+    h[StringVariablesParser.parse(key, variables, env, silent)] =
+      StringVariablesParser.parse(value, variables, env, silent)
   end
   return h
 end


### PR DESCRIPTION
This makes something like this possible:

```http
< ./auth.js
POST {{API_URL}} HTTP/1.1
Content-Type: application/json
{{AUTH_HEADER_NAME}}: {{AUTH_HEADER_VALUE}}
```

auth.js

```js
if (request.environment.get("API_ENVIRONMENT") === "local") {
  request.variables.set("AUTH_HEADER_NAME", "Context");
  request.variables.set("AUTH_HEADER_VALUE", request.environment.get("AUTH_CONTEXT"));
} else {
  request.variables.set("AUTH_HEADER_NAME", "AccessToken");
  request.variables.set("AUTH_HEADER_VALUE", request.environment.get("AUTH_TOKEN"));
}
```