### PR TITLE
Add default keymaps

### DIFF
--- a/lua/kulala/config/init.lua
+++ b/lua/kulala/config/init.lua
@@ -1,4 +1,5 @@
 local FS = require("kulala.utils.fs")
+local keymaps = require("kulala.config.keymaps")
 local M = {}
 
 M.defaults = {
@@ -9,9 +10,6 @@ M.defaults = {
   -- Display mode
   -- possible values: "split", "float"
   display_mode = "split",
-  -- q to close the float (only used when display_mode is set to "float")
-  -- possible values: true, false
-  q_to_close_float = false,
   -- split direction
   -- possible values: "vertical", "horizontal"
   split_direction = "vertical",
@@ -90,6 +88,42 @@ M.defaults = {
   -- this will show the variable name and value as float
   -- possible values: false, "float"
   show_variable_info_text = false,
+
+  -- set to true to enable default keymaps (check docs or {plugins_path}/kulala.nvim/lua/kulala/config/keymaps.lua for details)
+  -- or override default keymaps as shown in the example below.
+  ---@type boolean|table
+  global_keymaps = false,
+  --[[
+    {
+      ["Send request"] = { -- sets global mapping
+        "<leader>Rs",
+        function() require("kulala").run() end,
+        mode = { "n", "v" }, -- optional mode, default is v
+        desc = "Send request" -- optional description, otherwise inferred from the key
+      },
+      ["Send all requests"] = {
+        "<leader>Ra",
+        function() require("kulala").run_all() end,
+        mode = { "n", "v" },
+        ft = "http", -- sets mapping for *.http files only
+      },
+      ["Replay the last request"] = {
+        "<leader>Rr",
+        function() require("kulala").replay() end,
+        ft = { "http", "rest" }, -- sets mapping for specified file types
+      },
+    ["Find request"] = false -- set to false to disable
+    },
+  ]]
+
+  -- Kulala UI keymaps, override with custom keymaps as required (check docs or {plugins_path}/kulala.nvim/lua/kulala/config/keymaps.lua for details)
+  ---@type boolean|table
+  kulala_keymaps = true,
+  --[[
+    {
+      ["Show headers"] = { "H", function() require("kulala.ui").show_headers() end, },
+    }
+  ]]
 }
 
 M.default_contenttype = {
@@ -102,6 +136,7 @@ M.options = M.defaults
 
 M.setup = function(config)
   M.options = vim.tbl_deep_extend("force", M.defaults, config or {})
+  keymaps.setup_global_keymaps()
 end
 
 M.set = function(config)

--- a/lua/kulala/config/keymaps.lua
+++ b/lua/kulala/config/keymaps.lua
@@ -1,0 +1,249 @@
+local M = {}
+
+M.default_global_keymaps = {
+  ["Open scratchpad"] = {
+    "<leader>Rb",
+    function()
+      require("kulala").scratchpad()
+    end,
+  },
+  ["Open kulala"] = {
+    "<leader>Ro",
+    function()
+      require("kulala").open()
+    end,
+  },
+  ["Close window"] = {
+    "<leader>Rq",
+    function()
+      require("kulala").close()
+    end,
+    ft = { "http", "rest" },
+  },
+  ["Copy as cURL"] = {
+    "<leader>Rc",
+    function()
+      require("kulala").copy()
+    end,
+    ft = { "http", "rest" },
+  },
+  ["Paste from curl"] = {
+    "<leader>RC",
+    function()
+      require("kulala").from_curl()
+    end,
+    ft = { "http", "rest" },
+  },
+  ["Inspect current request"] = {
+    "<leader>Ri",
+    function()
+      require("kulala").inspect()
+    end,
+    ft = { "http", "rest" },
+  },
+  ["Select environment"] = {
+    "<leader>Re",
+    function()
+      require("kulala").set_selected_env()
+    end,
+    ft = { "http", "rest" },
+  },
+  ["Send request"] = {
+    "<leader>Rs",
+    function()
+      require("kulala").run()
+    end,
+    mode = { "n", "v" },
+  },
+  ["Send request <cr>"] = {
+    "<CR>",
+    function()
+      require("kulala").run()
+    end,
+    mode = { "n", "v" },
+    ft = { "http", "rest" },
+  },
+  ["Send all requests"] = {
+    "<leader>Ra",
+    function()
+      require("kulala").run_all()
+    end,
+    mode = { "n", "v" },
+  },
+  ["Replay the last request"] = {
+    "<leader>Rr",
+    function()
+      require("kulala").replay()
+    end,
+  },
+  ["Download GraphQL schema"] = {
+    "<leader>Rg",
+    function()
+      require("kulala").download_graphql_schema()
+    end,
+    ft = { "http", "rest" },
+  },
+  ["Jump to next request"] = {
+    "<leader>Rn",
+    function()
+      require("kulala").jump_next()
+    end,
+    ft = { "http", "rest" },
+  },
+  ["Jump to previous request"] = {
+    "<leader>Rp",
+    function()
+      require("kulala").jump_prev()
+    end,
+    ft = { "http", "rest" },
+  },
+  ["Find request"] = {
+    "<leader>Rf",
+    function()
+      require("kulala").search()
+    end,
+    ft = { "http", "rest" },
+  },
+  ["Toggle headers/body"] = {
+    "<leader>Rt",
+    function()
+      require("kulala").toggle_view()
+    end,
+    ft = { "http", "rest" },
+  },
+  ["Show stats"] = {
+    "<leader>RS",
+    function()
+      require("kulala").show_stats()
+    end,
+    ft = { "http", "rest" },
+  },
+}
+
+-- Keymaps for Kulala window only
+M.default_kulala_keymaps = {
+  ["Show headers"] = {
+    "H",
+    function()
+      require("kulala.ui").show_headers()
+    end,
+  },
+  ["Show body"] = {
+    "B",
+    function()
+      require("kulala.ui").show_body()
+    end,
+  },
+  ["Show headers and body"] = {
+    "A",
+    function()
+      require("kulala.ui").show_headers_body()
+    end,
+  },
+  ["Show verbose"] = {
+    "V",
+    function()
+      require("kulala.ui").show_verbose()
+    end,
+  },
+  ["Show script output"] = {
+    "O",
+    function()
+      require("kulala.ui").show_script_output()
+    end,
+  },
+  ["Show stats"] = {
+    "S",
+    function()
+      require("kulala.ui").show_stats()
+    end,
+  },
+  ["Close"] = {
+    "q",
+    function()
+      require("kulala.ui").close_kulala_buffer()
+    end,
+  },
+}
+
+local function collect_global_keymaps()
+  local config = require("kulala.config")
+  local config_global_keymaps = config.options.global_keymaps
+  local global_keymaps, ft_keymaps = {}, {}
+
+  if not config_global_keymaps then
+    return
+  end
+
+  config_global_keymaps = type(config_global_keymaps) == "table"
+      and vim.tbl_extend("force", M.default_global_keymaps, config_global_keymaps)
+    or M.default_global_keymaps
+
+  vim.iter(config_global_keymaps):each(function(name, map)
+    if map then
+      map.desc = map.desc or name
+
+      if map.ft then
+        vim.iter({ map.ft }):flatten():each(function(ft)
+          ft_keymaps[ft] = vim.list_extend(ft_keymaps[ft] or {}, { map })
+        end)
+      else
+        global_keymaps = vim.list_extend(global_keymaps, { map })
+      end
+    end
+  end)
+
+  return global_keymaps, ft_keymaps
+end
+
+local function set_keymap(map, buf)
+  vim.keymap.set(map.mode or "n", map[1], map[2], { buffer = buf, desc = map.desc, silent = true })
+end
+
+local function create_ft_autocommand(ft, maps)
+  vim.api.nvim_create_autocmd({ "BufEnter", "BufRead", "BufNewFile", "BufFilePost" }, {
+    group = vim.api.nvim_create_augroup("Kulala filetype setup for *." .. ft, { clear = true }),
+    pattern = { "*." .. ft },
+    desc = "Kulala: setup keymaps for http filtypes",
+    callback = function(ev)
+      vim.iter(maps):each(function(map)
+        set_keymap(map, ev.buf)
+      end)
+    end,
+  })
+end
+
+M.setup_kulala_keymaps = function(buf)
+  local config = require("kulala.config")
+  local config_kulala_keymaps = config.options.kulala_keymaps
+
+  if not config_kulala_keymaps then
+    return
+  end
+
+  config_kulala_keymaps = type(config_kulala_keymaps) == "table"
+      and vim.tbl_extend("force", M.default_kulala_keymaps, config_kulala_keymaps)
+    or M.default_kulala_keymaps
+
+  vim.iter(config_kulala_keymaps or {}):each(function(name, map)
+    if map then
+      map.desc = map.desc or name
+      set_keymap(map, buf)
+    end
+  end)
+end
+
+M.setup_global_keymaps = function()
+  local global_keymaps, ft_keymaps = collect_global_keymaps()
+
+  vim.iter(global_keymaps or {}):each(function(map)
+    set_keymap(map)
+  end)
+
+  vim.iter(ft_keymaps or {}):each(function(ft, maps)
+    create_ft_autocommand(ft, maps)
+  end)
+  return global_keymaps, ft_keymaps
+end
+
+return M

--- a/lua/kulala/ui/winbar.lua
+++ b/lua/kulala/ui/winbar.lua
@@ -1,49 +1,24 @@
-local UICallbacks = require("kulala.ui.callbacks")
 local CONFIG = require("kulala.config")
 local M = {}
 
 local winbar_info = {
   body = {
     desc = "Body (B)",
-    action = function()
-      require("kulala.ui").show_body()
-    end,
-    keymap = "B",
   },
   headers = {
     desc = "Headers (H)",
-    action = function()
-      require("kulala.ui").show_headers()
-    end,
-    keymap = "H",
   },
   headers_body = {
     desc = "All (A)",
-    action = function()
-      require("kulala.ui").show_headers_body()
-    end,
-    keymap = "A",
   },
   verbose = {
     desc = "Verbose (V)",
-    action = function()
-      require("kulala.ui").show_verbose()
-    end,
-    keymap = "V",
   },
   script_output = {
     desc = "Script Output (O)",
-    action = function()
-      require("kulala.ui").show_script_output()
-    end,
-    keymap = "O",
   },
   stats = {
     desc = "Stats (S)",
-    action = function()
-      require("kulala").show_stats()
-    end,
-    keymap = "S",
   },
 }
 
@@ -51,16 +26,6 @@ local winbar_info = {
 M.winbar_sethl = function()
   vim.api.nvim_set_hl(0, "KulalaTab", { link = "TabLine" })
   vim.api.nvim_set_hl(0, "KulalaTabSel", { link = "TabLineSel" })
-end
-
----set local key mapping
----@param buf integer|nil Buffer
-M.winbar_set_key_mapping = function(buf)
-  if buf and CONFIG.get().winbar then
-    for _, value in pairs(winbar_info) do
-      vim.keymap.set("n", value.keymap, value.action, { silent = true, buffer = buf })
-    end
-  end
 end
 
 ---@param buf integer Buffer id
@@ -94,11 +59,6 @@ M.toggle_winbar_tab = function(buf, win_id, view)
   vim.api.nvim_set_option_value("winbar", value, { win = win_id })
 
   M.winbar_sethl()
-  M.winbar_set_key_mapping(buf)
 end
-
-UICallbacks.add("on_replace_buffer", function(_, new_buffer)
-  M.winbar_set_key_mapping(new_buffer)
-end)
 
 return M

--- a/tests/functional/ui_spec.lua
+++ b/tests/functional/ui_spec.lua
@@ -1,6 +1,7 @@
 ---@diagnostic disable: undefined-field, redefined-local
 local GLOBALS = require("kulala.globals")
 local CONFIG = require("kulala.config")
+local KEYMAPS = require("kulala.config.keymaps")
 local DB = require("kulala.db")
 local kulala = require("kulala")
 
@@ -12,7 +13,7 @@ local s = require("test_helper.stubs")
 
 local assert = require("luassert")
 
-describe("requests", function()
+describe("UI", function()
   local curl, system, wait_for_requests
   local input, notify, dynamic_vars
   local lines, result, expected, http_buf, ui_buf
@@ -403,6 +404,124 @@ describe("requests", function()
       expected = "curl -X 'GET' -v -s -A 'kulala.nvim/" .. GLOBALS.VERSION .. "' 'http://localhost:3001/request_1'"
       result = vim.fn.getreg("+")
       assert.are.same(expected, result)
+    end)
+  end)
+
+  describe("keymaps", function()
+    local global_keymaps = KEYMAPS.default_global_keymaps
+    local kulala_keymaps = KEYMAPS.default_kulala_keymaps
+    local keymaps_n, keymaps_v
+
+    vim.g.mapleader = ","
+
+    before_each(function()
+      h.delete_all_maps()
+    end)
+
+    describe("global keymaps", function()
+      before_each(function()
+        CONFIG.setup({
+          global_keymaps = {
+            ["Inspect current request"] = {
+              "<leader>RI",
+              function() end,
+            },
+            ["Open scratchpad"] = false,
+          },
+        })
+
+        keymaps_n = vim.tbl_keys(h.get_maps())
+        keymaps_v = vim.tbl_keys(h.get_maps(nil, "v"))
+      end)
+
+      it("sets default keymaps", function()
+        http_buf = h.create_buf(lines, "test.txt")
+
+        expected = global_keymaps["Open kulala"][1]
+        assert.is_true(vim.tbl_contains(keymaps_n, expected))
+
+        expected = global_keymaps["Send request"][1]
+        assert.is_true(vim.tbl_contains(keymaps_v, expected))
+
+        expected = global_keymaps["Jump to next request"][1]
+        assert.is_false(vim.tbl_contains(keymaps_n, expected))
+      end)
+
+      it("sets filetype keymaps", function()
+        vim.cmd.e("test.http")
+        keymaps_n = vim.tbl_keys(h.get_maps(http_buf))
+
+        expected = global_keymaps["Find request"][1]
+        assert.is_true(vim.tbl_contains(keymaps_n, expected))
+      end)
+
+      it("sets and disables custom keymaps", function()
+        expected = "<leader>RI"
+        assert.is_true(vim.tbl_contains(keymaps_n, expected))
+        assert.is_false(vim.tbl_contains(keymaps_n, global_keymaps["Open scratchpad"][1]))
+      end)
+    end)
+
+    describe("global keymaps", function()
+      it("disables default keymaps", function()
+        CONFIG.setup({ global_keymaps = false })
+
+        local keymaps_n = vim.tbl_keys(h.get_maps())
+        expected = global_keymaps["Open kulala"][1]
+        assert.is_false(vim.tbl_contains(keymaps_n, expected))
+      end)
+    end)
+
+    describe("local keymaps", function()
+      before_each(function()
+        s.Fs:stub_read_file({ [GLOBALS.BODY_FILE] = h.load_fixture("fixtures/request_2_headers_body.txt") })
+
+        CONFIG.setup({
+          default_view = "body",
+          kulala_keymaps = {
+            ["Show headers"] = {
+              "HH",
+              function() end,
+            },
+            ["Show headers and body"] = false,
+          },
+        })
+
+        kulala.open()
+        ui_buf = vim.fn.bufnr(kulala_name)
+
+        keymaps_n = vim.tbl_keys(h.get_maps(ui_buf))
+      end)
+
+      after_each(function()
+        kulala.close()
+        s.Fs:read_file_reset()
+      end)
+
+      it("sets default keymaps", function()
+        expected = kulala_keymaps["Show body"][1]
+        assert.is_true(vim.tbl_contains(keymaps_n, expected))
+      end)
+
+      it("sets custom keymaps", function()
+        assert.is_true(vim.tbl_contains(keymaps_n, "HH"))
+
+        expected = kulala_keymaps["Show headers and body"][1]
+        assert.is_false(vim.tbl_contains(keymaps_n, expected))
+      end)
+
+      it("disbales default keymaps", function()
+        kulala.close()
+        CONFIG.setup({ kulala_keymaps = false })
+
+        kulala.open()
+        ui_buf = vim.fn.bufnr(kulala_name)
+
+        keymaps_n = vim.tbl_keys(h.get_maps(ui_buf))
+
+        expected = kulala_keymaps["Show body"][1]
+        assert.is_false(vim.tbl_contains(keymaps_n, expected))
+      end)
     end)
   end)
 end)


### PR DESCRIPTION
1. Added default keymaps: global, filetype, local and initialization logic to enable/disable/customize keymaps.
2. Added two config options: 
- `global_keymaps = false` by default - will enable/disable/customize default keymaps globally and for http/rest filetypes.
-  `kulala_keymaps = true` by default - will enable/disable/customize default keymaps for Kulala UI.
