### PR TITLE
Fix: Send one-off request async (#368)

### DIFF
--- a/lua/kulala/config/init.lua
+++ b/lua/kulala/config/init.lua
@@ -20,6 +20,8 @@ M.defaults = {
   default_env = "dev",
   -- enable/disable debug mode
   debug = false,
+  -- default timeout for the request, set to nil to disable
+  request_timeout = nil,
   -- default formatters/pathresolver for different content types
   contenttypes = {
     ["application/json"] = {


### PR DESCRIPTION
Resolves #368 

Problem:
- a regression introduced in #346 when removing `vim.fn.jobstart` in favour of `vim.system`.   Single requests when run with `vim.system` are queued with `wait()`.

Fix: 

- Skip `wait()` for single requests.

Change:
- added config option `request_timeout = nil` by default, to set max timeout.