### PR TITLE
Fix: update docs for API hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,30 @@ Via [lazy.nvim](https://github.com/folke/lazy.nvim):
 ### Configuration
 
 ```lua
-{ 'mistweaverco/kulala.nvim', opts = {} },
+require("lazy").setup({
+  {
+    "mistweaverco/kulala.nvim",
+    keys = {
+      { "<leader>Rs", desc = "Send request" },
+      { "<leader>Ra", desc = "Send all requests" },
+      { "<leader>Rb", desc = "Open scratchpad" },
+    },
+    ft = {"http", "rest"},
+    opts = {
+      -- your configuration comes here
+      global_keymaps = false,
+    },
+  },
+})
 ```
-> [!NOTE]
-> `opts` needs to be at least an empty table `{}` and can't be completely omitted.
 
-See [configuration options](https://neovim.getkulala.net/docs/getting-started/configuration-options) for more information.
+> [!WARNING]
+>`opts` needs to be at least an empty table `{}` and can't be completely omitted.
+
+> [!NOTE]
+> By default global keymaps are disabled, change to `global_keymaps = true` to get a complete set of key mappings for Kulala. Check the [keymaps documentation](https://neovim.getkulala.net/docs/getting-started/keymaps) for details.
+
+See complete [configuration options](https://neovim.getkulala.net/docs/getting-started/configuration-options) for more information.
 
 ## Honorable mentions
 

--- a/docs/docs/getting-started/configuration-options.md
+++ b/docs/docs/getting-started/configuration-options.md
@@ -44,17 +44,19 @@ the Kulala plugin with the available `opts`:
   contenttypes = {
     ["application/json"] = {
       ft = "json",
-      formatter = FS.command_exists("jq") and { "jq", "." } or nil,
-      pathresolver = require("kulala.parser.jsonpath").parse,
+      formatter = vim.fn.executable("jq") == 1 and { "jq", "." },
+      pathresolver = function(...)
+        return require("kulala.parser.jsonpath").parse(...)
+      end,
     },
     ["application/xml"] = {
       ft = "xml",
-      formatter = FS.command_exists("xmllint") and { "xmllint", "--format", "-" } or nil,
-      pathresolver = FS.command_exists("xmllint") and { "xmllint", "--xpath", "{{path}}", "-" } or nil,
+      formatter = vim.fn.executable("xmllint") == 1 and { "xmllint", "--format", "-" },
+      pathresolver = vim.fn.executable("xmllint") == 1 and { "xmllint", "--xpath", "{{path}}", "-" },
     },
     ["text/html"] = {
       ft = "html",
-      formatter = FS.command_exists("xmllint") and { "xmllint", "--format", "--html", "-" } or nil,
+      formatter = vim.fn.executable("xmllint") == 1 and { "xmllint", "--format", "--html", "-" },
       pathresolver = nil,
     },
   },
@@ -94,20 +96,20 @@ the Kulala plugin with the available `opts`:
     -- enable/disable request summary in the output window
     show_request_summary = true,
     summaryTextHighlight = "Special",
-  },
 
-  -- scratchpad default contents
-  scratchpad_default_contents = {
-    "@MY_TOKEN_NAME=my_token_value",
-    "",
-    "# @name scratchpad",
-    "POST https://httpbin.org/post HTTP/1.1",
-    "accept: application/json",
-    "content-type: application/json",
-    "",
-    "{",
-    '  "foo": "bar"',
-    "}",
+    -- scratchpad default contents
+    scratchpad_default_contents = {
+      "@MY_TOKEN_NAME=my_token_value",
+      "",
+      "# @name scratchpad",
+      "POST https://httpbin.org/post HTTP/1.1",
+      "accept: application/json",
+      "content-type: application/json",
+      "",
+      "{",
+      '  "foo": "bar"',
+      "}",
+    },
   },
 
   -- set to true to enable default keymaps (check docs or {plugins_path}/kulala.nvim/lua/kulala/config/keymaps.lua for details)

--- a/docs/docs/getting-started/install.md
+++ b/docs/docs/getting-started/install.md
@@ -13,11 +13,15 @@ Via [lazy.nvim](https://github.com/folke/lazy.nvim):
 ### Basic configuration
 
 ```lua title="init.lua"
-require('lazy').setup({
+require("lazy").setup({
   {
-    'mistweaverco/kulala.nvim',
-    keys = {"<leader>Rs", "<leader>Ra", "<leader>Ro"},
-    ft = {"http", "rest"},
+    "mistweaverco/kulala.nvim",
+    keys = {
+      { "<leader>Rs", desc = "Send request" },
+      { "<leader>Ra", desc = "Send all requests" },
+      { "<leader>Rb", desc = "Open scratchpad" },
+    },
+    ft = { "http", "rest" },
     opts = {
       -- your configuration comes here
       global_keymaps = false,

--- a/docs/docs/usage/api.md
+++ b/docs/docs/usage/api.md
@@ -10,10 +10,10 @@ The queue of callbacks resets after this event is triggered.
 
 ```lua
 require('kulala.api').on("after_next_request", function(data)
-  print("Request completed")
-  print("Headers: " .. data.headers)
-  print("Body: " .. data.body)
-  print("Complete response: " .. data.response)
+  vim.print("Request completed")
+  vim.print("Headers: " .. data.headers)
+  vim.print("Body: " .. data.body)
+  vim.print("Complete response: ", data.response)
 end)
 ```
 
@@ -23,10 +23,10 @@ Triggered after a request has been successfully completed.
 
 ```lua
 require('kulala.api').on("after_request", function(data)
-  print("Request completed")
-  print("Headers: " .. data.headers)
-  print("Body: " .. data.body)
-  print("Complete response: " .. data.response)
+  vim.print("Request completed")
+  vim.print("Headers: " .. data.headers)
+  vim.print("Body: " .. data.body)
+  vim.print("Complete response: ", data.response)
 end)
 ```
 

--- a/lua/kulala/cmd/init.lua
+++ b/lua/kulala/cmd/init.lua
@@ -151,13 +151,13 @@ local function process_errors(request, request_status, processing_errors)
     )
   end
 
-  local message = ("Errors in request %s at line: %s\n%s\n%s"):format(
+  local message = ("Errors in request %s at line: %s\n%s"):format(
     request.url,
     request.show_icon_line_number or "-",
-    request_status.errors or "",
-    processing_errors or ""
+    request_status.errors or ""
   )
   Logger.error(message, 2)
+  Logger.error(processing_errors or "", 2)
 end
 
 local function handle_response(request_status, parsed_request, callback)

--- a/lua/kulala/config/init.lua
+++ b/lua/kulala/config/init.lua
@@ -38,17 +38,19 @@ M.defaults = {
   contenttypes = {
     ["application/json"] = {
       ft = "json",
-      formatter = FS.command_exists("jq") and { "jq", "." } or nil,
-      pathresolver = require("kulala.parser.jsonpath").parse,
+      formatter = vim.fn.executable("jq") == 1 and { "jq", "." },
+      pathresolver = function(...)
+        return require("kulala.parser.jsonpath").parse(...)
+      end,
     },
     ["application/xml"] = {
       ft = "xml",
-      formatter = FS.command_exists("xmllint") and { "xmllint", "--format", "-" } or nil,
-      pathresolver = FS.command_exists("xmllint") and { "xmllint", "--xpath", "{{path}}", "-" } or nil,
+      formatter = vim.fn.executable("xmllint") == 1 and { "xmllint", "--format", "-" },
+      pathresolver = vim.fn.executable("xmllint") == 1 and { "xmllint", "--xpath", "{{path}}", "-" },
     },
     ["text/html"] = {
       ft = "html",
-      formatter = FS.command_exists("xmllint") and { "xmllint", "--format", "--html", "-" } or nil,
+      formatter = vim.fn.executable("xmllint") == 1 and { "xmllint", "--format", "--html", "-" },
       pathresolver = nil,
     },
   },
@@ -85,20 +87,20 @@ M.defaults = {
     -- enable/disable request summary in the output window
     show_request_summary = true,
     summaryTextHighlight = "Special",
-  },
 
-  -- scratchpad default contents
-  scratchpad_default_contents = {
-    "@MY_TOKEN_NAME=my_token_value",
-    "",
-    "# @name scratchpad",
-    "POST https://httpbin.org/post HTTP/1.1",
-    "accept: application/json",
-    "content-type: application/json",
-    "",
-    "{",
-    '  "foo": "bar"',
-    "}",
+    -- scratchpad default contents
+    scratchpad_default_contents = {
+      "@MY_TOKEN_NAME=my_token_value",
+      "",
+      "# @name scratchpad",
+      "POST https://httpbin.org/post HTTP/1.1",
+      "accept: application/json",
+      "content-type: application/json",
+      "",
+      "{",
+      '  "foo": "bar"',
+      "}",
+    },
   },
 
   -- enable/disable debug mode

--- a/lua/kulala/parser/document.lua
+++ b/lua/kulala/parser/document.lua
@@ -274,7 +274,7 @@ M.get_document = function()
     line_offset = line_offset or vim.fn.line(".")
   end
 
-  content_lines = content_lines and PARSER_UTILS.strip_invalid_chars(content_lines or {})
+  content_lines = FS.is_non_http_file() and PARSER_UTILS.strip_invalid_chars(content_lines or {}) or content_lines
 
   content_lines = content_lines or vim.api.nvim_buf_get_lines(buf, 0, -1, false) -- finally: get the whole buffer if the three methods above failed
   line_offset = line_offset or 0


### PR DESCRIPTION
- update docs: API
- update readme: install section
- update docs: config options
- update config: replace `FS.command` with `vim.fs.executable`
- minor fix: document parser: strip comment chars only for non-http files