### PR TITLE
fix: use nowait for keymaps

### DIFF
--- a/lua/kulala/config/keymaps.lua
+++ b/lua/kulala/config/keymaps.lua
@@ -221,7 +221,7 @@ local function collect_global_keymaps()
 end
 
 local function set_keymap(map, buf)
-  vim.keymap.set(map.mode or "n", map[1], map[2], { buffer = buf, desc = map.desc, silent = true })
+  vim.keymap.set(map.mode or "n", map[1], map[2], { buffer = buf, desc = map.desc, silent = true, nowait = true })
 end
 
 local function create_ft_autocommand(ft, maps)


### PR DESCRIPTION
Hello!

With the introduction of `[` and `]` as means to navigate the request history, one thing that's bugging me out is the delay. Since there are default mappings that start with `[` and `]` (`[[` and `]]` respectfully), neovim waits `'timeoutlen'` for another key before executing the initial action.

To handle that, we can just make all mappings use the `nowait` option. From my testing, this does not interfere with any other default keymaps.