### PR TITLE
fix: use screen size instead of win size for float

### DIFF
--- a/lua/kulala/ui/init.lua
+++ b/lua/kulala/ui/init.lua
@@ -109,8 +109,8 @@ local function open_kulala_window(buf)
   local request_win = vim.fn.win_findbuf(DB.get_current_buffer())[1] or vim.api.nvim_get_current_win()
 
   if config.display_mode == "float" then
-    local width = math.max(vim.api.nvim_win_get_width(0) - 10, 1)
-    local height = math.max(vim.api.nvim_win_get_height(0) - 10, 1)
+    local width = math.max(vim.o.columns - 10, 1)
+    local height = math.max(vim.o.lines - 10, 1)
 
     win_config = {
       title = "Kulala",


### PR DESCRIPTION
`nvim_win_get_width` and `nvim_win_get_height` returns the size of the current window, so if we have many windows in 1 tab, the opening float would be really small. I think we should use size of the screen instead
![image](https://github.com/user-attachments/assets/7cad7122-df80-436a-bf21-31ffcd12cdff)