### PR TITLE
Fix(parser): replay and comments

### DIFF
--- a/lua/kulala/parser/document.lua
+++ b/lua/kulala/parser/document.lua
@@ -298,9 +298,11 @@ M.get_document = function()
     request.end_line = block.end_lnum
 
     for relative_linenr, line in ipairs(block.lines) do
-      -- skip comments, silently skip URLs that are commented out
-      if line:match("^#%S") then
-        if parse_url(line:sub(2)) then skip_block = true end
+      if line:match("^# @") then
+        parse_metadata(request, line)
+      -- skip comments and silently skip URLs that are commented out
+      elseif line:match("^%s*#") or line:match("^%s*//") then
+        if parse_url(line:match("^[^#/]+") or "") then skip_block = true end
       -- end of inline scripting
       elseif is_request_line and line:match("^%%}$") then
         is_prerequest_handler_script_inline = false
@@ -313,8 +315,6 @@ M.get_document = function()
       -- inline scripting active: add the line to the prerequest handler scripts
       elseif is_prerequest_handler_script_inline then
         table.insert(request.scripts.pre_request.inline, line)
-      elseif line:sub(1, 1) == "#" then
-        parse_metadata(request, line)
       -- we're still in(/before) the request line and we have a pre-request inline handler script
       elseif is_request_line and line:match("^< %{%%$") then
         is_prerequest_handler_script_inline = true

--- a/lua/kulala/parser/request.lua
+++ b/lua/kulala/parser/request.lua
@@ -10,6 +10,7 @@ local STRING_UTILS = require("kulala.utils.string")
 local CURL_FORMAT_FILE = FS.get_plugin_path({ "parser", "curl-format.json" })
 local Logger = require("kulala.logger")
 local StringVariablesParser = require("kulala.parser.string_variables_parser")
+local utils = require("kulala.utils.table")
 
 local M = {}
 
@@ -18,27 +19,27 @@ M.scripts.javascript = require("kulala.parser.scripts.javascript")
 
 ---@class Request
 ---@field metadata { name: string, value: string }[] -- Metadata of the request
+---@field environment table<string, string|number> -- The environment- and document-variables
 ---@field method string -- The HTTP method of the request
----@field grpc GrpcCommand|nil -- The gRPC command
----@field url_raw string -- The raw URL as it appears in the document
 ---@field url string -- The URL with variables and dynamic variables replaced
+---@field url_raw string -- The raw URL as it appears in the document
+---@field http_version string -- The HTTP version of the request
 ---@field headers table<string, string> -- The headers with variables and dynamic variables replaced
----@field headers_display table<string, string> -- The headers with variables and dynamic variables replaced and sanitized
 ---@field headers_raw table<string, string> -- The headers as they appear in the document
+---@field headers_display table<string, string> -- The headers with variables and dynamic variables replaced and sanitized
+---@field ft string -- The filetype of the document
 ---@field cookie string -- The cookie as it appears in the document
+---@field body string|nil -- The body with variables and dynamic variables replaced
 ---@field body_raw string|nil -- The raw body as it appears in the document
 ---@field body_computed string|nil -- The computed body as sent by curl; with variables and dynamic variables replaced
 ---@field body_display string|nil -- The body with variables and dynamic variables replaced and sanitized
 ---(e.g. with binary files replaced with a placeholder)
----@field body string|nil -- The body with variables and dynamic variables replaced
----@field environment table<string, string|number> -- The environment- and document-variables
----@field cmd string[] -- The command to execute the request
----@field ft string -- The filetype of the document
----@field http_version string -- The HTTP version of the request
 ---@field show_icon_line_number number|nil -- The line number to show the icon
----@field scripts Scripts -- The scripts to run before and after the request
 ---@field redirect_response_body_to_files ResponseBodyToFile[]
+---@field scripts Scripts -- The scripts to run before and after the request
+---@field cmd string[] -- The command to execute the request
 ---@field body_temp_file string -- The path to the temporary file containing the body
+---@field grpc GrpcCommand|nil -- The gRPC command
 ---@field processed boolean -- Indicates if request has been already processed, used by replay()
 
 ---@class GrpcCommand
@@ -54,38 +55,13 @@ local default_grpc_command = {
 }
 
 ---@type Request
+---@diagnostic disable-next-line: missing-fields
 local default_request = {
-  metadata = {},
-  method = "GET",
-  grpc = nil,
-  http_version = "",
-  url = "",
-  url_raw = "",
-  headers = {},
-  headers_display = {},
-  headers_raw = {},
-  cookie = "",
-  body = nil,
-  body_raw = nil,
-  body_computed = nil,
-  body_display = nil,
-  cmd = {},
-  ft = "text",
   environment = {},
-  redirect_response_body_to_files = {},
-  scripts = {
-    pre_request = {
-      inline = {},
-      files = {},
-    },
-    post_request = {
-      inline = {},
-      files = {},
-    },
-  },
-  show_icon_line_number = 1,
+  headers_display = {},
+  ft = "text",
+  cmd = {},
   body_temp_file = "",
-  processed = false
 }
 
 local function process_grpc_flags(request, flag, value)
@@ -507,20 +483,11 @@ function M.get_basic_request_data(requests, line_nr)
 
   if not document_request then return end
 
-  --TODO: replace with merge
-  request.scripts.pre_request = document_request.scripts.pre_request
-  request.scripts.post_request = document_request.scripts.post_request
-  request.show_icon_line_number = document_request.show_icon_line_number
-  request.headers = document_request.headers
-  request.cookie = document_request.cookie
-  request.headers_raw = document_request.headers_raw
+  request = vim.tbl_extend("keep", request, document_request)
+  utils.remove_keys(request, { "body", "variables", "start_line", "end_line" })
+
   request.url_raw = document_request.url
-  request.method = document_request.method
-  request.http_version = document_request.http_version
   request.body_raw = document_request.body
-  request.body_display = document_request.body_display
-  request.metadata = document_request.metadata
-  request.redirect_response_body_to_files = document_request.redirect_response_body_to_files
 
   return request
 end

--- a/lua/kulala/utils/table.lua
+++ b/lua/kulala/utils/table.lua
@@ -17,4 +17,10 @@ M.slice = function(tbl, first, last)
   return sliced
 end
 
+M.remove_keys = function(tbl, keys)
+  vim.iter(keys):each(function(key)
+    tbl[key] = nil
+  end)
+end
+
 return M

--- a/tests/functional/parser_spec.lua
+++ b/tests/functional/parser_spec.lua
@@ -96,7 +96,7 @@ describe("requests", function()
         assert.is_same(result.url, "https://httpbin.org/Time%2012%")
       end)
 
-      it("skips reequests comented out with # ", function()
+      it("skips requests commented out with # ", function()
         h.create_buf(
           ([[
             # @name SIMPLE REQUEST
@@ -109,6 +109,42 @@ describe("requests", function()
 
         result = parser.parse() or {}
         assert.is.same({}, result)
+      end)
+
+      it("skips lines commented out with # ", function()
+        h.create_buf(
+          ([[
+            # @name SIMPLE REQUEST
+            POST https://httpbingo.org/simple
+
+            {
+              # "skip": "true",
+              "test": "value"
+            }
+      ]]):to_table(true),
+          "test.http"
+        )
+
+        result = parser.parse() or {}
+        assert.is_same(result.body:gsub("\n",""), '{"test": "value"}')
+      end)
+
+      it("skips lines commented out with //", function()
+        h.create_buf(
+          ([[
+            # @name SIMPLE REQUEST
+            POST https://httpbingo.org/simple
+
+            {
+              // "skip": "true",
+              "test": "value"
+            }
+      ]]):to_table(true),
+          "test.http"
+        )
+
+        result = parser.parse() or {}
+        assert.is_same(result.body:gsub("\n", ""), '{"test": "value"}')
       end)
 
       it("processes headers", function()

--- a/tests/functional/parser_spec.lua
+++ b/tests/functional/parser_spec.lua
@@ -81,6 +81,21 @@ describe("requests", function()
         })
       end)
 
+      it("processes request only if it has not been processed yet", function()
+        h.create_buf(
+          ([[
+            POST https://httpbin.org/Time 12:00 Date 24/12
+      ]]):to_table(true),
+          "test.http"
+        )
+
+        result = parser.parse() or {}
+        assert.is_same(result.url, "https://httpbin.org/Time%2012%")
+
+        result = parser.parse({result})
+        assert.is_same(result.url, "https://httpbin.org/Time%2012%")
+      end)
+
       it("skips reequests comented out with # ", function()
         h.create_buf(
           ([[

--- a/tests/functional/parser_spec.lua
+++ b/tests/functional/parser_spec.lua
@@ -84,16 +84,18 @@ describe("requests", function()
       it("processes request only if it has not been processed yet", function()
         h.create_buf(
           ([[
-            POST https://httpbin.org/Time 12:00 Date 24/12
+            GET https://typicode.com/todos?date=2020-01-01 12:34:56
       ]]):to_table(true),
           "test.http"
         )
 
         result = parser.parse() or {}
-        assert.is_same(result.url, "https://httpbin.org/Time%2012%")
+        assert.is_same("https://typicode.com/todos?date=2020-01-01%2012%3A34%3A56", result.url)
 
-        result = parser.parse({result})
-        assert.is_same(result.url, "https://httpbin.org/Time%2012%")
+        result.processed = true
+
+        result = parser.parse({ result })
+        assert.is_same("https://typicode.com/todos?date=2020-01-01%2012%3A34%3A56", result.url)
       end)
 
       it("skips requests commented out with # ", function()
@@ -126,7 +128,7 @@ describe("requests", function()
         )
 
         result = parser.parse() or {}
-        assert.is_same(result.body:gsub("\n",""), '{"test": "value"}')
+        assert.is_same(result.body:gsub("\n", ""), '{"test": "value"}')
       end)
 
       it("skips lines commented out with //", function()

--- a/tests/functional/ui_spec.lua
+++ b/tests/functional/ui_spec.lua
@@ -616,7 +616,7 @@ describe("UI", function()
         GLOBALS.VERSION
       )
       result = vim.fn.getreg("+")
-      assert.has_string(result, expected)
+      assert.has_string(expected, result)
     end)
 
     it("it shows help hint and window", function()


### PR DESCRIPTION
Fix: allow `#` and `//` comment chars on non-first char line position.  Closes #410 
Fix: disable repeated request processing when replaying.  Closes #415 