### PR TITLE
Feat: add import and run commands

### DIFF
--- a/docs/docs/usage/import-and-run-http.md
+++ b/docs/docs/usage/import-and-run-http.md
@@ -1,0 +1,55 @@
+# Import and Run *.http files
+
+Kulala lets you import HTTP requests from other .http files. You can:
+
+- Run all HTTP requests from specified files
+- Run specific HTTP requests from imported files
+
+## Usage
+
+### Run all requests from another .http file
+
+In your .http file, enter `run` followed by the name of another .http that you want to include. If the file is in the same directory, enter its name. Otherwise, specify a relative or absolute path to it. For example:
+
+```http
+run ./requests/get-requests.http
+```
+
+### Run specific requests from another .http file
+
+At the top of your .http file, enter `import` followed by the name or path of another .http that contains necessary requests.
+Enter `run` and specify the name of the request that you want to run prefixed with `#`. The name of the request is specified next to delimiter `###`, otherwise the `URL` without the http version is used.
+To autocomplete available requests, use the `Ctrl-X Ctrl-U` shortcut.
+
+
+```http get-requests.http
+### Request 1
+
+GET https://httpbin.org/advanced_1 HTTP/1.1
+
+###
+
+POST https://httpbin.org/advanced_2 HTTP/1.1
+```
+
+```http
+import ./requests/get-requests.http
+
+run #Request 1
+run #POST https://httpbin.org/advanced_2
+```
+
+### Override variables from imported .http files
+
+If the imported .http file contains variables, you can specify or change their values for specific executions.
+Enter `run` and specify the name of an .http file or a request.
+
+After the name of a request or a file, enter variables in the `(@variable=value)` format. To specify multiple variables, separate them by commas. For example:
+
+```http
+import new-requests.http
+
+run #Request with one var (@host=example.com)
+
+run #Request with two vars (@host=example.com, @user=userName)
+```

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -49,6 +49,7 @@ const sidebars: SidebarsConfig = {
         "usage/using-environment-variables",
         "usage/using-variables",
         "usage/testing-and-reporting",
+        "usage/import-and-run-http",
         'usage/http-file-spec',
       ],
     },

--- a/lua/kulala/cmd/init.lua
+++ b/lua/kulala/cmd/init.lua
@@ -319,6 +319,7 @@ end
 ---Parses and executes DocumentRequest/s:
 ---if requests are provied then runs the first request in the list
 ---if line_nr is provided then runs the request from current buffer within the line number
+---if line_nr is 0, then runs visually selected requests
 ---or runs all requests in the document
 ---@param requests? DocumentRequest[]|nil
 ---@param line_nr? number|nil
@@ -336,10 +337,10 @@ M.run_parser = function(requests, line_nr, callback)
   if not requests then return Logger.error("No requests found in the document") end
 
   if line_nr and line_nr > 0 then
-    local request = DOCUMENT_PARSER.get_request_at(requests, line_nr)
-    if not request then return Logger.error("No request found at current line") end
+    local requests_l = DOCUMENT_PARSER.get_request_at(requests, line_nr)
+    if not requests_l then return Logger.error("No request found at current line") end
 
-    reqs_to_process = { request }
+    reqs_to_process = requests_l
   end
 
   reqs_to_process = reqs_to_process or requests

--- a/lua/kulala/parser/document.lua
+++ b/lua/kulala/parser/document.lua
@@ -404,10 +404,7 @@ M.get_document = function(lines)
       -- skip comments and silently skip URLs that are commented out
       elseif line:match("^%s*#") or line:match("^%s*//") then
         local _, url = parse_url(request, line:match("^%s*[#/]+%s*(.+)") or "")
-        if url then
-          is_request_line = false
-          skip_block = true
-        end
+        if url then skip_block = true end
       -- end of inline scripting
       elseif is_request_line and line:match("^import ") then
         parse_import_command(variables, imported_requests, line)

--- a/lua/kulala/parser/document.lua
+++ b/lua/kulala/parser/document.lua
@@ -403,7 +403,7 @@ M.get_document = function(lines)
         parse_metadata(request, line)
       -- skip comments and silently skip URLs that are commented out
       elseif line:match("^%s*#") or line:match("^%s*//") then
-        local _, url = parse_url(line:match("^%s*[#/]+%s*(.+)") or "")
+        local _, url = parse_url(request, line:match("^%s*[#/]+%s*(.+)") or "")
         if url then
           is_request_line = false
           skip_block = true

--- a/lua/kulala/parser/request.lua
+++ b/lua/kulala/parser/request.lua
@@ -482,6 +482,7 @@ end
 function M.get_basic_request_data(requests, line_nr)
   local request = vim.deepcopy(default_request)
   local document_request = DOCUMENT_PARSER.get_request_at(requests, line_nr)
+  document_request = document_request and document_request[1]
 
   if not document_request then return end
 
@@ -490,7 +491,7 @@ function M.get_basic_request_data(requests, line_nr)
   request.url_raw = document_request.url
   request.body_raw = document_request.body
 
-  utils.remove_keys(request, { "body", "variables", "start_line", "end_line" })
+  utils.remove_keys(request, { "name", "file", "body", "variables", "start_line", "end_line" })
 
   return request
 end

--- a/lua/kulala/utils/complete.lua
+++ b/lua/kulala/utils/complete.lua
@@ -1,0 +1,38 @@
+local Parser = require("kulala.parser.document")
+
+local M = {}
+
+-- Determine if the current line is a request line (method + URL)
+local function is_run(line)
+  return line:match("^run")
+end
+
+local function complete_requests(_)
+  local _, _, requests = Parser.get_document()
+
+  return vim
+    .iter(requests)
+    :map(function(request)
+      return {
+        word = "#" .. request.name,
+        menu = request.file,
+      }
+    end)
+    :totable()
+end
+
+function M.complete(findstart, base)
+  local line = vim.api.nvim_get_current_line()
+
+  -- First call - find the start position of the word to complete
+  if findstart == 1 then
+    if is_run(line) then return line:find("^run") - 2 end
+    return -1
+  else
+    -- Second call - return completion items
+    if is_run(line) then return complete_requests(base) end
+    return {}
+  end
+end
+
+return M

--- a/lua/kulala/utils/table.lua
+++ b/lua/kulala/utils/table.lua
@@ -23,4 +23,11 @@ M.remove_keys = function(tbl, keys)
   end)
 end
 
+--- Merge table 2 into table 1, keeping existing keys
+M.merge = function(tbl_1, tbl_2)
+  vim.iter(tbl_2):each(function(k, v)
+    if not tbl_1[k] then tbl_1[k] = v end
+  end)
+end
+
 return M

--- a/tests/functional/parser_spec.lua
+++ b/tests/functional/parser_spec.lua
@@ -423,6 +423,7 @@ describe("requests", function()
 
           assert.is_same("new_bar", result["foobar"])
           assert.is_same("new_username", result["ENV_USER"])
+          assert.is_same("project_name", result["ENV_PROJECT"])
         end)
       end)
     end)

--- a/tests/functional/parser_spec.lua
+++ b/tests/functional/parser_spec.lua
@@ -358,6 +358,73 @@ describe("requests", function()
           },
         })
       end)
+
+      describe("it processes run and import directives", function()
+        local doc_parser = require("kulala.parser.document")
+
+        -- import|run filename_in_cwd|relative_path|absolute_path
+        it("run - filename", function()
+          h.create_buf(
+            ([[
+            POST https://httpbin.org/post HTTP/1.1
+            Content-Type: text/plain
+
+            ###
+            run tests/functional/requests/advanced_A.http
+          ]]):to_table(true),
+            "test.http"
+          )
+
+          result = select(2, doc_parser.get_document()) or {}
+          assert.is_same("https://httpbin.org/post", result[1].url)
+          assert.is_same("https://httpbin.org/advanced_1", result[2].url)
+          assert.is_same("https://httpbin.org/advanced_2", result[3].url)
+        end)
+
+        it("import/run - filename", function()
+          h.create_buf(
+            ([[
+            import tests/functional/requests/advanced_A.http
+
+            POST https://httpbin.org/post HTTP/1.1
+            Content-Type: text/plain
+
+            ###
+            run #Request 1
+            run #POST https://httpbin.org/advanced_2
+          ]]):to_table(true),
+            "test.http"
+          )
+
+          result = select(2, doc_parser.get_document()) or {}
+
+          assert.is_same("https://httpbin.org/post", result[1].url)
+          assert.is_same("https://httpbin.org/advanced_1", result[2].url)
+          assert.is_same("https://httpbin.org/advanced_2", result[3].url)
+        end)
+
+        it("run - replaces variables", function()
+          -- run #GET request with two vars (@host=example.com, @user=userName)
+          h.create_buf(
+            ([[
+            import tests/functional/requests/advanced_A.http
+
+            POST https://httpbin.org/post HTTP/1.1
+            Content-Type: text/plain
+
+            ###
+            run #Request 1 (@foobar=new_bar, @ENV_USER = new_username)
+            run #POST https://httpbin.org/advanced_2
+          ]]):to_table(true),
+            "test.http"
+          )
+
+          result = doc_parser.get_document() or {}
+
+          assert.is_same("new_bar", result["foobar"])
+          assert.is_same("new_username", result["ENV_USER"])
+        end)
+      end)
     end)
   end)
 end)

--- a/tests/functional/requests/advanced_A.http
+++ b/tests/functional/requests/advanced_A.http
@@ -2,6 +2,8 @@
 @ENV_USER = some_username
 @ENV_PROJECT = project_name
 
+### Request 1
+
 POST https://httpbin.org/advanced_1 HTTP/1.1
 Content-Type: application/json
 Accept: application/json


### PR DESCRIPTION
Feat: add import and run commands (IntelliJ Comp)

- `import *.http` command
- `run *.http` - to run the whole http file
- `run #Request name` - to run a specific request from imported file
- `<C-x> <C-u>` - to autocomplete imported request names