### PR TITLE
feat(virt_text): use 'combine' to blend with cursorline

### DIFF
--- a/lua/kulala/inlay/init.lua
+++ b/lua/kulala/inlay/init.lua
@@ -67,7 +67,10 @@ M.show = function(event, linenr, text)
     text = icon .. " " .. text
   end
 
-  vim.api.nvim_buf_set_extmark(bufnr, NS, linenr - 1, 0, { virt_text = { { text, config.icons.textHighlight } } })
+  vim.api.nvim_buf_set_extmark(bufnr, NS, linenr - 1, 0, {
+    hl_mode = "combine",
+    virt_text = { { text, config.icons.textHighlight } },
+  })
 end
 
 return M


### PR DESCRIPTION
Virtual text when used with `cursorline` overrides the BG color of the cursorline, using `hl_mode = "combine"` makes it so they blend together.

Before:
![image](https://github.com/user-attachments/assets/bfeb00a8-e665-4b11-a33a-ed32bbc323e7)

After:
![image](https://github.com/user-attachments/assets/07f107bf-8b18-4055-9e94-ff47fd4bd25d)
