### PR TITLE
fix: fix winbar highlights

### DIFF
--- a/lua/kulala/ui/winbar.lua
+++ b/lua/kulala/ui/winbar.lua
@@ -60,9 +60,10 @@ M.toggle_winbar_tab = function(buf, win_id, view)
     local info = winbar_info[key]
 
     if info then
-      local desc = info.desc .. " %*"
+      local desc = info.desc
       desc = keymaps[info.keymap] and desc .. " (" .. keymaps[info.keymap][1] .. ")" or desc
       desc = view == key and "%#KulalaTabSel# " .. desc or "%#KulalaTab# " .. desc
+      desc = desc .. " %*"
 
       table.insert(winbar_title, desc)
     end


### PR DESCRIPTION
Old:
<img width="913" alt="Screenshot 2025-04-15 at 20 46 18" src="https://github.com/user-attachments/assets/a577b45b-88f9-41cd-966d-bc925e652fb2" />

New:
<img width="941" alt="Screenshot 2025-04-15 at 20 47 48" src="https://github.com/user-attachments/assets/226c098c-a3cc-4d89-a228-34e1d7fc8db7" />

It is hard to read which tab is activated with the current winbar.
This PR aims to fix that by making the shortcut key part of the tab highlight.