### PR TITLE
Add `global_keymaps_prefix` option to prevent overriding user keymaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ JS and Lua scripting: Pre-request, Post-request, Conditional, Inline, External
 
 Authentication: Basic, Bearer, Digest, NTLM, OAuth2, Negotiate, AWS, SSL
 
-Response formatting and filtering
+Response formatting and live filtering
 
 Assertions, automated testing and reporting
 
-Bulit-in LSP completion and formatting
+Built-in LSP completion and formatting
 
 CLI tooling and CI hooks
 
@@ -52,9 +52,6 @@ Scratchpad: for making requests
 
 
 #### Together with [Kulala Language Server](https://github.com/mistweaverco/kulala-ls) and [Kulala Formatter](https://github.com/mistweaverco/kulala-fmt), Kulala aims to provide the best REST Client experience on the web without leaving your favourite editor!
-
-We are closely watching products, such as IntelliJ HTTP Client, VS Code REST Client, Postman, Hurl, Bruno, rest.nvim and others for ideas and inspiration and our focus is to 
-achieve 100% compatibility with **IntelliJ HTTP Client**, while providing the features of others and more.
 
 
 #### We love feature requests and feedback, so if you have any ideas or suggestions, please let us know!  

--- a/lua/kulala/config/defaults.lua
+++ b/lua/kulala/config/defaults.lua
@@ -180,7 +180,7 @@ local M = {
 
   -- The globalKeymapPrefix setting allows users to define a custom prefix for all global keymaps registered by this plugin.
   -- This prevents conflicts with existing user-defined keymaps by namespacing the plugin's key bindings under a unique prefix.
-  global_keymaps_prefix = "R",
+  global_keymaps_prefix = "<leader>R",
 
   -- Kulala UI keymaps, override with custom keymaps as required (check docs or {plugins_path}/kulala.nvim/lua/kulala/config/keymaps.lua for details)
   ---@type boolean|table

--- a/lua/kulala/config/defaults.lua
+++ b/lua/kulala/config/defaults.lua
@@ -178,6 +178,10 @@ local M = {
     },
   ]]
 
+  -- The globalKeymapPrefix setting allows users to define a custom prefix for all global keymaps registered by this plugin.
+  -- This prevents conflicts with existing user-defined keymaps by namespacing the plugin's key bindings under a unique prefix.
+  global_keymaps_prefix = "R",
+
   -- Kulala UI keymaps, override with custom keymaps as required (check docs or {plugins_path}/kulala.nvim/lua/kulala/config/keymaps.lua for details)
   ---@type boolean|table
   kulala_keymaps = true,

--- a/lua/kulala/config/keymaps.lua
+++ b/lua/kulala/config/keymaps.lua
@@ -254,14 +254,14 @@ M.default_kulala_keymaps = {
 local function collect_global_keymaps()
   local config = require("kulala.config")
   local config_global_keymaps = config.options.global_keymaps
-  local global_keymaps, ft_keymaps = {}, {}
   local prefix = config.options.global_keymaps_prefix
+  local global_keymaps, ft_keymaps = {}, {}
 
   if not config_global_keymaps then return end
 
   config_global_keymaps = type(config_global_keymaps) == "table"
       and vim.tbl_extend("force", M.default_global_keymaps, config_global_keymaps)
-    or M.default_global_keymaps
+    or vim.deepcopy(M.default_global_keymaps)
 
   vim.iter(config_global_keymaps):each(function(name, map)
     if map then

--- a/lua/kulala/config/keymaps.lua
+++ b/lua/kulala/config/keymaps.lua
@@ -267,7 +267,7 @@ local function collect_global_keymaps()
     if map then
       map.desc = map.desc or name
 
-      map[1] = "<leader>" .. prefix .. map[1]
+      map[1] = prefix .. map[1]
 
       if map.ft then
         vim.iter({ map.ft }):flatten():each(function(ft)

--- a/lua/kulala/config/keymaps.lua
+++ b/lua/kulala/config/keymaps.lua
@@ -2,61 +2,61 @@ local M = {}
 
 M.default_global_keymaps = {
   ["Open scratchpad"] = {
-    "<leader>Rb",
+    "b",
     function()
       require("kulala").scratchpad()
     end,
   },
   ["Open kulala"] = {
-    "<leader>Ro",
+    "o",
     function()
       require("kulala").open()
     end,
   },
   ["Close window"] = {
-    "<leader>Rq",
+    "q",
     function()
       require("kulala").close()
     end,
     ft = { "http", "rest" },
   },
   ["Copy as cURL"] = {
-    "<leader>Rc",
+    "c",
     function()
       require("kulala").copy()
     end,
     ft = { "http", "rest" },
   },
   ["Paste from curl"] = {
-    "<leader>RC",
+    "C",
     function()
       require("kulala").from_curl()
     end,
     ft = { "http", "rest" },
   },
   ["Inspect current request"] = {
-    "<leader>Ri",
+    "i",
     function()
       require("kulala").inspect()
     end,
     ft = { "http", "rest" },
   },
   ["Select environment"] = {
-    "<leader>Re",
+    "e",
     function()
       require("kulala").set_selected_env()
     end,
     ft = { "http", "rest" },
   },
   ["Manage Auth Config"] = {
-    "<leader>Ru",
+    "u",
     function()
       require("kulala.ui.auth_manager").open_auth_config()
     end,
     ft = { "http", "rest" },
   },
   ["Send request"] = {
-    "<leader>Rs",
+    "s",
     function()
       require("kulala").run()
     end,
@@ -71,69 +71,69 @@ M.default_global_keymaps = {
     ft = { "http", "rest" },
   },
   ["Send all requests"] = {
-    "<leader>Ra",
+    "a",
     function()
       require("kulala").run_all()
     end,
     mode = { "n", "v" },
   },
   ["Replay the last request"] = {
-    "<leader>Rr",
+    "r",
     function()
       require("kulala").replay()
     end,
   },
   ["Download GraphQL schema"] = {
-    "<leader>Rg",
+    "g",
     function()
       require("kulala").download_graphql_schema()
     end,
     ft = { "http", "rest" },
   },
   ["Jump to next request"] = {
-    "<leader>Rn",
+    "n",
     function()
       require("kulala").jump_next()
     end,
     ft = { "http", "rest" },
   },
   ["Jump to previous request"] = {
-    "<leader>Rp",
+    "p",
     function()
       require("kulala").jump_prev()
     end,
     ft = { "http", "rest" },
   },
   ["Find request"] = {
-    "<leader>Rf",
+    "f",
     function()
       require("kulala").search()
     end,
     ft = { "http", "rest" },
   },
   ["Toggle headers/body"] = {
-    "<leader>Rt",
+    "t",
     function()
       require("kulala").toggle_view()
     end,
     ft = { "http", "rest" },
   },
   ["Show stats"] = {
-    "<leader>RS",
+    "S",
     function()
       require("kulala").show_stats()
     end,
     ft = { "http", "rest" },
   },
   ["Clear globals"] = {
-    "<leader>Rx",
+    "x",
     function()
       require("kulala").scripts_clear_global()
     end,
     ft = { "http", "rest" },
   },
   ["Clear cached files"] = {
-    "<leader>RX",
+    "X",
     function()
       require("kulala").clear_cached_files()
     end,
@@ -255,6 +255,7 @@ local function collect_global_keymaps()
   local config = require("kulala.config")
   local config_global_keymaps = config.options.global_keymaps
   local global_keymaps, ft_keymaps = {}, {}
+  local prefix = config.options.global_keymaps_prefix or "R"
 
   if not config_global_keymaps then return end
 
@@ -265,6 +266,8 @@ local function collect_global_keymaps()
   vim.iter(config_global_keymaps):each(function(name, map)
     if map then
       map.desc = map.desc or name
+
+      map[1] = "<leader>" .. prefix .. map[1]
 
       if map.ft then
         vim.iter({ map.ft }):flatten():each(function(ft)

--- a/lua/kulala/config/keymaps.lua
+++ b/lua/kulala/config/keymaps.lua
@@ -255,7 +255,7 @@ local function collect_global_keymaps()
   local config = require("kulala.config")
   local config_global_keymaps = config.options.global_keymaps
   local global_keymaps, ft_keymaps = {}, {}
-  local prefix = config.options.global_keymaps_prefix or "R"
+  local prefix = config.options.global_keymaps_prefix
 
   if not config_global_keymaps then return end
 

--- a/tests/functional/keymaps_spec.lua
+++ b/tests/functional/keymaps_spec.lua
@@ -31,7 +31,7 @@ describe("keymaps", function()
       CONFIG.setup({
         global_keymaps = {
           ["Inspect current request"] = {
-            "<leader>RI",
+            "I",
             function() end,
           },
           ["Open scratchpad"] = false,


### PR DESCRIPTION
This pull request introduces a new globalKeymapPrefix configuration option.
Previously, the global keymap could unintentionally override user-defined keymaps.
By setting a custom prefix, users can now prevent conflicts and better integrate with their own configurations.

