### PR TITLE
docs: Add note about url encoding (#500)

### DIFF
--- a/doc/kulala.http-file-spec.txt
+++ b/doc/kulala.http-file-spec.txt
@@ -21,7 +21,7 @@ request.
 `Absolute` format: `HTTPMethod` `URL` `HTTPVersion`:
 
 >http
-    GET https://weater.com:7220/weatherforecast
+    GET https://weater.com:7220/weatherforecast?city=New York&day=2025-05-07
 <
 
 `Origin` format: `HTTPMethod` `URL`:
@@ -29,7 +29,7 @@ request.
 Single line
 
 >http
-    GET /api/get
+    GET /api/get?id=123&value=some thing
     Host: example.com
 <
 
@@ -41,7 +41,7 @@ Multiline
         /html
         /get
         ?id=123
-        &value=content
+        &value=some "longer" content
 <
 
 `Asterisk` format: `HTTPMethod` `URL`:
@@ -71,9 +71,9 @@ Multiline
     - `ws`
     - `wss`
 - `URL` is the URL to send the request to. The URL can include query string
-    parameters. The URL doesn’t have to point to a local web project and can
-    point to any URL. Numeric IPv4 `http://127.0.0.1` and IPv6 `http://[::1]`
-    addresses are supported.
+    parameters, which are automatically url-encoded. The URL doesn’t have
+    to point to a local web project and can point to any URL. Numeric 
+    IPv4 `http://127.0.0.1` and IPv6 `http://[::1]` addresses are supported.
 - `HTTPVersion` is optional and specifies the HTTP version that should be used,
     that’s, `HTTP/1.1`, `HTTP/2`, or `HTTP/3`.
 

--- a/docs/docs/usage/http-file-spec.md
+++ b/docs/docs/usage/http-file-spec.md
@@ -11,14 +11,14 @@ Kulala supports `absolute`, `origin` and `asterisk path` formats for HTTP reques
 
 `Absolute` format: `HTTPMethod` `URL` `HTTPVersion`: 
 ```http
-GET https://weater.com:7220/weatherforecast
+GET https://weater.com:7220/weatherforecast?city=New York&day=2025-05-07
 ```
 
  `Origin` format: `HTTPMethod` `URL`:
 
 Single line
 ```http
-GET /api/get
+GET /api/get?id=123&value=some thing
 Host: example.com
 ```
 
@@ -29,7 +29,7 @@ GET http://example.com:8080
     /html
     /get
     ?id=123
-    &value=content
+    &value=some "longer" content
 ```
 
  `Asterisk` format: `HTTPMethod` `URL`:
@@ -59,7 +59,7 @@ Host: http://example.com:8080
   - `wss`
 
 - `URL` is the URL to send the request to.
-  The URL can include query string parameters.
+  The URL can include query string parameters, which are automatically url-encoded.
   The URL doesn't have to point to a local web project and can point to any URL.
   Numeric IPv4 `http://127.0.0.1` and IPv6 `http://[::1]` addresses are supported.
 


### PR DESCRIPTION
I added a few words to the docs making clear that this is supported out of the box.