### PR TITLE
Fix highlight compatibility with Neovim 0.10+ and older versions

### DIFF
--- a/lua/kulala/ui/float.lua
+++ b/lua/kulala/ui/float.lua
@@ -50,7 +50,7 @@ local function float_defaults(opts)
     { "buf", "name", "auto_size", "row_offset", "col_offset", "hl_group", "ft", "close_keymaps", "auto_close" }
   )
 
-  return vim.tbl_extend("keep", win_opts, {
+  local win_opts_base = {
     relative = "win",
     width = width,
     height = height,
@@ -59,9 +59,13 @@ local function float_defaults(opts)
     style = "minimal",
     border = "none",
     focusable = false,
-    mouse = true,
     zindex = 100,
-  })
+  }
+
+  -- Add 'mouse = true' only if Neovim is older than 0.10
+  if vim.fn.has("nvim-0.10") == 0 then win_opts_base.mouse = true end
+
+  return vim.tbl_extend("keep", win_opts, win_opts_base)
 end
 
 local function set_close_keymaps(buf, win, keymaps)

--- a/lua/kulala/ui/utils.lua
+++ b/lua/kulala/ui/utils.lua
@@ -23,7 +23,12 @@ local function highlight_range(bufnr, ns, start_pos, end_pos, hl_group, priority
   start_pos = type(start_pos) == "table" and start_pos or { start_pos, 0 }
   end_pos = type(end_pos) == "table" and end_pos or { end_pos, -1 }
 
-  vim.hl.range(bufnr, ns, hl_group, start_pos, end_pos, { priority = priority or 1 })
+  -- Check Neovim version and use the appropriate highlight API
+  local highlight = vim.fn.has("nvim-0.10") == 1
+    and vim.highlight.range
+    or vim.hl.range
+
+  highlight(bufnr, ns, hl_group, start_pos, end_pos, { priority = priority or 1 })
 end
 
 local function highlight_column(bufnr, ns, start_pos, end_pos, hl_group, priority)


### PR DESCRIPTION
- Replaced deprecated vim.hl.range with vim.highlight.range for Neovim 0.10+
- Added version check to conditionally use the correct API for highlighting
- Removed invalid 'mouse' option for nvim_open_win in Neovim 0.10+