### PR TITLE
refactor: use FS.read_json for VSCode settings and remove unused Json module

### DIFF
--- a/lua/kulala/parser/env.lua
+++ b/lua/kulala/parser/env.lua
@@ -1,7 +1,6 @@
 local Config = require("kulala.config")
 local DB = require("kulala.db")
 local FS = require("kulala.utils.fs")
-local Json = require("kulala.utils.json")
 local Logger = require("kulala.logger")
 local Table = require("kulala.utils.table")
 
@@ -9,33 +8,13 @@ local M = {}
 
 local function get_vscode_env()
   if Config.get().vscode_rest_client_environmentvars then
-    local vscode_dir = FS.find_file_in_parent_dirs(".vscode")
+    local vscode_settings_file = FS.find_file_in_parent_dirs(".vscode/settings.json")
     local code_workspace_file = FS.find_file_in_parent_dirs(function(name, _)
       return name:match(".*%.code%-workspace$")
     end)
 
-    if vscode_dir then
-      local success, settings_json_content = pcall(vim.fn.readfile, vscode_dir .. "/settings.json")
-
-      if success then
-        local settings = Json.parse(settings_json_content)
-        if not (settings and settings["rest-client.environmentVariables"]) then return end
-
-        local f = settings["rest-client.environmentVariables"]
-        if f["$shared"] then
-          DB.update().http_client_env_shared =
-            vim.tbl_deep_extend("force", DB.find_unique("http_client_env_shared"), f["$shared"])
-        end
-
-        f["$shared"] = nil
-        DB.update().http_client_env = vim.tbl_deep_extend("force", DB.find_unique("http_client_env"), f)
-      end
-    end
-
-    if code_workspace_file then
-      local code_workspace = FS.read_json(code_workspace_file) or {}
-      local settings = code_workspace.settings
-
+    if vscode_settings_file then
+      local settings = FS.read_json(vscode_settings_file) or {}
       if not (settings and settings["rest-client.environmentVariables"]) then return end
 
       local f = settings["rest-client.environmentVariables"]
@@ -43,6 +22,23 @@ local function get_vscode_env()
         DB.update().http_client_env_shared =
           vim.tbl_deep_extend("force", DB.find_unique("http_client_env_shared"), f["$shared"])
       end
+
+      f["$shared"] = nil
+      DB.update().http_client_env = vim.tbl_deep_extend("force", DB.find_unique("http_client_env"), f)
+    end
+
+    if code_workspace_file then
+      local code_workspace = FS.read_json(code_workspace_file) or {}
+
+      local settings = code_workspace.settings
+      if not (settings and settings["rest-client.environmentVariables"]) then return end
+
+      local f = settings["rest-client.environmentVariables"]
+      if f["$shared"] then
+        DB.update().http_client_env_shared =
+          vim.tbl_deep_extend("force", DB.find_unique("http_client_env_shared"), f["$shared"])
+      end
+
       f["$shared"] = nil
       DB.update().http_client_env = vim.tbl_deep_extend("force", DB.find_unique("http_client_env"), f)
     end


### PR DESCRIPTION
## Description
Fixes issue where `Json.parse(settings_json_content)` returns nil by using `FS.read_json` instead.

### Changes
- Removed unused `Json` module
- Switched to `FS.read_json` for reading VSCode settings files
- Simplified file reading logic

### Why
The current implementation using `Json.parse` was returning nil, causing VSCode settings to not be properly loaded. Using `FS.read_json` resolves this issue.