### PR TITLE
fix(parser): vscode settings parse

### DIFF
--- a/lua/kulala/parser/env.lua
+++ b/lua/kulala/parser/env.lua
@@ -18,6 +18,7 @@ local function get_vscode_env()
       local success, settings_json_content = pcall(vim.fn.readfile, vscode_dir .. "/settings.json")
 
       if success then
+        settings_json_content = table.concat(settings_json_content)
         local settings = Json.parse(settings_json_content)
         if not (settings and settings["rest-client.environmentVariables"]) then return end
 


### PR DESCRIPTION
Originally, I couldn't load the VSCode settings environment when I opened Telescope by calling  `set_selected_env()`.
I found out that:
```lua
local success, settings_json_content = pcall(vim.fn.readfile, vscode_dir .. "/settings.json")
```
`settings_json_content` is actually a table, but
```lua
local settings = Json.parse(settings_json_content)
```
`Json.parse` requires a string.
After I concatenated all the lines in `settings_json_content`, I was able to load the VSCode settings correctly.