### PR TITLE
fix(lsp): lsp root directory

### DIFF
--- a/lua/kulala/cmd/lsp.lua
+++ b/lua/kulala/cmd/lsp.lua
@@ -1006,7 +1006,7 @@ function M.start_lsp(buf, ft)
   local client_id = vim.lsp.start({
     name = "kulala",
     cmd = server,
-    root_dir = ft,
+    root_dir = vim.fs.root(0, ".git") or vim.fn.getcwd() or ft,
     bufnr = buf,
     on_init = function(_client) end,
     on_exit = function(_code, _signal) end,


### PR DESCRIPTION
https://github.com/mistweaverco/kulala.nvim/issues/567

I fixed with finding `.git` as it's root directory or using `vim.fn.getcwd()` when `.git` doesn't exists
but I couldn't make it nil. ( that occur an error )

![圖片](https://github.com/user-attachments/assets/c02605ef-caea-4cd5-aeed-bf3746968344)
