### PR TITLE
fix(parser): no highlight with nvim_treesitter/main

### DIFF
--- a/lua/kulala/config/init.lua
+++ b/lua/kulala/config/init.lua
@@ -49,13 +49,6 @@ local function setup_treesitter_main()
   local ts_config = require("nvim-treesitter.config")
   local parser_path = Fs.get_plugin_path { "..", "tree-sitter" }
 
-  if
-    vim.tbl_contains(ts_config.get_installed("parsers"), "kulala_http")
-    and Db.settings.parser_ver == get_parser_ver(parser_path)
-  then
-    return vim.treesitter.language.register("kulala_http", { "http", "rest" })
-  end
-
   vim.api.nvim_create_autocmd("User", {
     pattern = "TSUpdate",
     callback = function()
@@ -71,6 +64,13 @@ local function setup_treesitter_main()
       }
     end,
   })
+
+  if
+    vim.tbl_contains(ts_config.get_installed("parsers"), "kulala_http")
+    and Db.settings.parser_ver == get_parser_ver(parser_path)
+  then
+    return vim.treesitter.language.register("kulala_http", { "http", "rest" })
+  end
 
   require("nvim-treesitter").install({ "kulala_http" }):wait(10000)
 


### PR DESCRIPTION
Hi there.

I'm on neovim nightly with main branch of nvim-treesitter, and the issue is treesitter highlighting only work at the `kulala_http` parser first installation, If I open another neovim instance, the highlighting didn't work.

This PR fixed this issue by moved [these lines](https://github.com/mistweaverco/kulala.nvim/blob/902fc21e8a3fee7ccace37784879327baa6d1ece/lua/kulala/config/init.lua#L59-L73) to above of the assert of installation and version check, These lines adding the custom `kulala_http` parser information, seems like this action should be done even the parser already installed.
