### PR TITLE
feat: add proxy support

### DIFF
--- a/lua/kulala/config/defaults.lua
+++ b/lua/kulala/config/defaults.lua
@@ -6,6 +6,19 @@ local M = {
   -- additional cURL options
   -- see: https://curl.se/docs/manpage.html
   additional_curl_options = {},
+  -- proxy configuration
+  proxy = {
+    -- HTTP/HTTPS proxy server (e.g., "http://proxy.example.com:8080")
+    server = nil,
+    -- proxy username (optional)
+    username = nil,
+    -- proxy password (optional)
+    password = nil,
+    -- SOCKS proxy server (e.g., "socks5://proxy.example.com:1080")
+    socks_proxy = nil,
+    -- bypass proxy for these hosts (comma-separated list)
+    no_proxy = nil,
+  },
   -- gRPCurl path, get from https://github.com/fullstorydev/grpcurl.git
   grpcurl_path = "grpcurl",
   -- websocat path, get from https://github.com/vi/websocat.git

--- a/lua/kulala/parser/request.lua
+++ b/lua/kulala/parser/request.lua
@@ -443,6 +443,31 @@ local function process_cookies(request)
   end
 end
 
+local function process_proxy_settings(request)
+  local proxy_config = CONFIG.get().proxy
+  if not proxy_config then return end
+
+  if proxy_config.server then
+    table.insert(request.cmd, "--proxy")
+    table.insert(request.cmd, proxy_config.server)
+    
+    if proxy_config.username and proxy_config.password then
+      table.insert(request.cmd, "--proxy-user")
+      table.insert(request.cmd, proxy_config.username .. ":" .. proxy_config.password)
+    end
+  end
+
+  if proxy_config.socks_proxy then
+    table.insert(request.cmd, "--socks5")
+    table.insert(request.cmd, proxy_config.socks_proxy)
+  end
+
+  if proxy_config.no_proxy then
+    table.insert(request.cmd, "--noproxy")
+    table.insert(request.cmd, proxy_config.no_proxy)
+  end
+end
+
 local function process_custom_curl_flags(request)
   local env = DB.find_unique("http_client_env") or {}
 
@@ -562,6 +587,7 @@ local function build_curl_command(request)
   process_headers(request)
   process_body(request)
   process_cookies(request)
+  process_proxy_settings(request)
   process_custom_curl_flags(request)
 
   table.insert(request.cmd, "-A")


### PR DESCRIPTION
  ## Summary

  Add proxy support to kulala.nvim, allowing users to route HTTP requests through proxy servers.

  ## Changes

  - **Configuration**: Added proxy configuration options to `lua/kulala/config/defaults.lua`
  - **Request Parser**: Enhanced `lua/kulala/parser/request.lua` to handle proxy settings
  - **Settings**: Updated local settings configuration

  ## Features Added

  - HTTP proxy support
  - Configurable proxy settings
  - Integration with existing request parsing system

  ## Testing

  - [ ] Tested with HTTP proxy server
  - [ ] Verified requests are properly routed through proxy
  - [ ] Confirmed backward compatibility (no proxy configuration)

  ## Documentation

  - [ ] Updated configuration documentation (if needed)
  - [ ] Added proxy configuration examples