### PR TITLE
feat: Mouse support for winbar ui

### DIFF
--- a/lua/kulala/ui/winbar.lua
+++ b/lua/kulala/ui/winbar.lua
@@ -6,34 +6,42 @@ local M = {}
 
 local winbar_info = {
   body = {
+    id = 1,
     desc = "Body",
     keymap = "Show body",
   },
   headers = {
+    id = 2,
     desc = "Headers",
     keymap = "Show headers",
   },
   headers_body = {
+    id = 3,
     desc = "All",
     keymap = "Show headers and body",
   },
   verbose = {
+    id = 4,
     desc = "Verbose",
     keymap = "Show verbose",
   },
   script_output = {
+    id = 5,
     desc = "Script Output",
     keymap = "Show script output",
   },
   stats = {
+    id = 8,
     desc = "Stats",
     keymap = "Show stats",
   },
   report = {
+    id = 6,
     desc = "Report",
     keymap = "Show report",
   },
   help = {
+    id = 7,
     desc = "Help",
     keymap = "Show help",
   },
@@ -43,6 +51,14 @@ local winbar_info = {
 M.winbar_sethl = function()
   vim.api.nvim_set_hl(0, "KulalaTab", { link = "TabLine" })
   vim.api.nvim_set_hl(0, "KulalaTabSel", { link = "TabLineSel" })
+end
+
+--- Select winbar tab
+---@param pane string Clicked pane
+M.select_winbar_tab = function(pane)
+  local default_panes = CONFIG.get().default_winbar_panes
+  local func_name = "show_"..default_panes[pane]
+  require("kulala.ui")[func_name]()
 end
 
 ---@param win_id integer|nil Window id
@@ -60,7 +76,7 @@ M.toggle_winbar_tab = function(buf, win_id, view)
     local info = winbar_info[key]
 
     if info then
-      local desc = info.desc
+      local desc = "%" .. info.id .. "@v:lua.require'kulala.ui.winbar'.select_winbar_tab@" .. info.desc
       local map = keymaps[info.keymap]
         and keymaps[info.keymap][1]
           :gsub("<[Ll]eader>", vim.g.mapleader or "%1")
@@ -68,7 +84,7 @@ M.toggle_winbar_tab = function(buf, win_id, view)
 
       desc = map and desc .. " (" .. map .. ")" or desc
       desc = view == key and "%#KulalaTabSel# " .. desc or "%#KulalaTab# " .. desc
-      desc = desc .. " %*"
+      desc = desc .. " %*%X"
 
       table.insert(winbar_title, desc)
     end

--- a/lua/kulala/ui/winbar.lua
+++ b/lua/kulala/ui/winbar.lua
@@ -6,42 +6,34 @@ local M = {}
 
 local winbar_info = {
   body = {
-    id = 1,
     desc = "Body",
     keymap = "Show body",
   },
   headers = {
-    id = 2,
     desc = "Headers",
     keymap = "Show headers",
   },
   headers_body = {
-    id = 3,
     desc = "All",
     keymap = "Show headers and body",
   },
   verbose = {
-    id = 4,
     desc = "Verbose",
     keymap = "Show verbose",
   },
   script_output = {
-    id = 5,
     desc = "Script Output",
     keymap = "Show script output",
   },
   stats = {
-    id = 8,
     desc = "Stats",
     keymap = "Show stats",
   },
   report = {
-    id = 6,
     desc = "Report",
     keymap = "Show report",
   },
   help = {
-    id = 7,
     desc = "Help",
     keymap = "Show help",
   },
@@ -53,11 +45,9 @@ M.winbar_sethl = function()
   vim.api.nvim_set_hl(0, "KulalaTabSel", { link = "TabLineSel" })
 end
 
---- Select winbar tab
----@param pane string Clicked pane
 M.select_winbar_tab = function(pane)
   local default_panes = CONFIG.get().default_winbar_panes
-  local func_name = "show_"..default_panes[pane]
+  local func_name = "show_" .. default_panes[pane]
   require("kulala.ui")[func_name]()
 end
 
@@ -72,11 +62,11 @@ M.toggle_winbar_tab = function(buf, win_id, view)
   local winbar = config.default_winbar_panes
   local winbar_title = {}
 
-  for _, key in ipairs(winbar) do
+  for i, key in ipairs(winbar) do
     local info = winbar_info[key]
 
     if info then
-      local desc = "%" .. info.id .. "@v:lua.require'kulala.ui.winbar'.select_winbar_tab@" .. info.desc
+      local desc = "%" .. i .. "@v:lua.require'kulala.ui.winbar'.select_winbar_tab@" .. info.desc
       local map = keymaps[info.keymap]
         and keymaps[info.keymap][1]
           :gsub("<[Ll]eader>", vim.g.mapleader or "%1")

--- a/tests/functional/ui_spec.lua
+++ b/tests/functional/ui_spec.lua
@@ -691,7 +691,8 @@ describe("UI", function()
       wait_for_requests(1)
 
       result = vim.api.nvim_get_option_value("winbar", { win = vim.fn.bufwinid(ui_buf) })
-      expected = "%#KulalaTabSel# Body (B) %* %#KulalaTab# Report (R) %* %#KulalaTab# Help (?) %* <- [ ] ->"
+      expected =
+        "%#KulalaTabSel# %1@v:lua.require'kulala.ui.winbar'.select_winbar_tab@Body (B) %*%X %#KulalaTab# %2@v:lua.require'kulala.ui.winbar'.select_winbar_tab@Report (R) %*%X %#KulalaTab# %3@v:lua.require'kulala.ui.winbar'.select_winbar_tab@Help (?) %*%X <- [ ] ->"
       assert.same(expected, result)
     end)
   end)


### PR DESCRIPTION
This PR adds mouse support for the winbar headers, so clicking on each item will navigate us there.
I dont have much experience contributing, so let me know if anything needs to be changed or removed.

Preview:

https://github.com/user-attachments/assets/d326eecd-2104-49a7-bdfd-ed2ab150667b

