### PR TITLE
Add cookies to graphql introspection request

### DIFF
--- a/lua/kulala/graphql/init.lua
+++ b/lua/kulala/graphql/init.lua
@@ -24,12 +24,27 @@ M.download_schema = function()
   filename = Fs.get_current_buffer_dir() .. "/" .. filename .. ".graphql-schema.json"
 
   local cmd = { Config.get().curl_path, "-s", "-o", filename, "-X", "POST" }
+  local cookies = {}
 
   for header_name, header_value in pairs(req.headers) do
     if header_name and header_value then
-      table.insert(cmd, "-H")
-      table.insert(cmd, header_name .. ": " .. header_value)
+      if header_name:lower() == "cookie" then
+        table.insert(cookies, header_value)
+      else
+        table.insert(cmd, "-H")
+        table.insert(cmd, header_name .. ": " .. header_value)
+      end
     end
+  end
+
+  if #cookies > 0 then
+    table.insert(cmd, "--cookie")
+    table.insert(cmd, table.concat(cookies, "; "))
+  end
+
+  if req.cookie and #req.cookie > 0 then
+    table.insert(cmd, "--cookie")
+    table.insert(cmd, req.cookie)
   end
 
   table.insert(cmd, "-d")

--- a/lua/kulala/graphql/init.lua
+++ b/lua/kulala/graphql/init.lua
@@ -24,22 +24,12 @@ M.download_schema = function()
   filename = Fs.get_current_buffer_dir() .. "/" .. filename .. ".graphql-schema.json"
 
   local cmd = { Config.get().curl_path, "-s", "-o", filename, "-X", "POST" }
-  local cookies = {}
 
   for header_name, header_value in pairs(req.headers) do
     if header_name and header_value then
-      if header_name:lower() == "cookie" then
-        table.insert(cookies, header_value)
-      else
-        table.insert(cmd, "-H")
-        table.insert(cmd, header_name .. ": " .. header_value)
-      end
+      table.insert(cmd, "-H")
+      table.insert(cmd, header_name .. ": " .. header_value)
     end
-  end
-
-  if #cookies > 0 then
-    table.insert(cmd, "--cookie")
-    table.insert(cmd, table.concat(cookies, "; "))
   end
 
   if req.cookie and #req.cookie > 0 then

--- a/tests/functional/requests_spec.lua
+++ b/tests/functional/requests_spec.lua
@@ -476,36 +476,33 @@ describe("requests", function()
       assert.has_string(result, expected)
     end)
 
-    it("downloads GraphQL schema with cookies",
-      function()
-        -- Stub the curl response
-        curl.stub {
-          ["https://countries.trevorblades.com"] = {
-            body = h.
-            load_fixture("fixtures/graphql_schema_body.txt"),
-          },
-        }
+    it("downloads GraphQL schema with cookies", function()
+      -- Stub the curl response
+      curl.stub {
+        ["https://countries.trevorblades.com"] = {
+          body = h.load_fixture("fixtures/graphql_schema_body.txt"),
+        },
+      }
 
-        -- Create a GraphQL request with Cookie header
-        h.create_buf(
-          ([[
+      -- Create a GraphQL request with Cookie header
+      h.create_buf(
+        ([[
            POST https://countries.trevorblades.com
            X-REQUEST-TYPE: GraphQL
            Cookie: session_id=abc123
 
            query { __schema { types { name } } }
          ]]):to_table(true),
-          "test.http"
-        )
+        "test.http"
+      )
 
-        kulala.download_graphql_schema()
+      kulala.download_graphql_schema()
 
-        -- Wait and verify the command includes --cookie flag
-        local request_cmd = system.args.cmd
-        assert.is_true(vim.tbl_contains(request_cmd, "--cookie"))
-        assert.is_true(vim.tbl_contains(request_cmd,
-          "session_id=abc123"))
-      end)
+      -- Wait and verify the command includes --cookie flag
+      local request_cmd = system.args.cmd
+      assert.is_true(vim.tbl_contains(request_cmd, "--cookie"))
+      assert.is_true(vim.tbl_contains(request_cmd, "session_id=abc123"))
+    end)
 
     it("parses GraphQL request", function()
       curl.stub {

--- a/tests/functional/requests_spec.lua
+++ b/tests/functional/requests_spec.lua
@@ -476,6 +476,37 @@ describe("requests", function()
       assert.has_string(result, expected)
     end)
 
+    it("downloads GraphQL schema with cookies",
+      function()
+        -- Stub the curl response
+        curl.stub {
+          ["https://countries.trevorblades.com"] = {
+            body = h.
+            load_fixture("fixtures/graphql_schema_body.txt"),
+          },
+        }
+
+        -- Create a GraphQL request with Cookie header
+        h.create_buf(
+          ([[
+           POST https://countries.trevorblades.com
+           X-REQUEST-TYPE: GraphQL
+           Cookie: session_id=abc123
+
+           query { __schema { types { name } } }
+         ]]):to_table(true),
+          "test.http"
+        )
+
+        kulala.download_graphql_schema()
+
+        -- Wait and verify the command includes --cookie flag
+        local request_cmd = system.args.cmd
+        assert.is_true(vim.tbl_contains(request_cmd, "--cookie"))
+        assert.is_true(vim.tbl_contains(request_cmd,
+          "session_id=abc123"))
+      end)
+
     it("parses GraphQL request", function()
       curl.stub {
         ["https://countries.trevorblades.com"] = {


### PR DESCRIPTION
Hi, first time contributing. Let me know if there is anything that needs refining. 

Currently, graphql introspection does not add cookies to the introspection request.
Therefore, it fails if there is a need for authentication. 

This MR adds the cookies under the `--cookie` flag to the request. 


