### PR TITLE
Allow repeat GRPC flags

### DIFF
--- a/docs/docs/usage/grpc.md
+++ b/docs/docs/usage/grpc.md
@@ -45,12 +45,6 @@ GRPC localhost:50051 list
 
 ###
 
-# @grpc-H header1:value1
-# @grpc-H header2:value2
-GRPC localhost:50051 helloworld.Greeter/SayHello
-
-###
-
 # @grpc-protoset my-protos.bin
 GRPC helloworld.Greeter/SayHello
 # address is optional when using proto files

--- a/tests/functional/grpc_spec.lua
+++ b/tests/functional/grpc_spec.lua
@@ -73,9 +73,9 @@ describe("grpc", function()
     it("supports repeated flags", function()
       h.create_buf(
         ([[
-          # @grpc-H testHeader1:testValue1
-          # @grpc-H testHeader2:testValue2
           GRPC localhost:50051 helloworld.Greeter/SayHello
+          testHeader1: testValue1
+          testHeader2: testValue2
       ]]):to_table(true),
         "test.http"
       )


### PR DESCRIPTION
grpcurl uses the `-H` flag to specify headers, so this needs to be allowed multiple times.
This PR changes GRPC requests to allow multiple values for a given flag and then repeats the flag for each value in the grpcurl command. See test/doc updates for an example