### PR TITLE
feat(scripts): allow deep object access via dot notation

### DIFF
--- a/lua/kulala/parser/scripts/engines/javascript/lib/package-lock.json
+++ b/lua/kulala/parser/scripts/engines/javascript/lib/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kulala-scripts-js",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kulala-scripts-js",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "devDependencies": {
         "@rollup/plugin-node-resolve": "15.3.0",
         "@rollup/plugin-terser": "0.4.4",
@@ -658,10 +658,11 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -950,10 +951,11 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1073,10 +1075,11 @@
       "dev": true
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -1675,10 +1678,11 @@
       }
     },
     "node_modules/eslint-config-love/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -2908,10 +2912,11 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },

--- a/lua/kulala/parser/scripts/engines/javascript/lib/package.json
+++ b/lua/kulala/parser/scripts/engines/javascript/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kulala-scripts-js",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "scripts": {
     "build": "rollup --config rollup.config.ts --configPlugin @rollup/plugin-typescript",
     "lint": "eslint"

--- a/lua/kulala/parser/scripts/engines/javascript/lib/src/lib/PostRequest.ts
+++ b/lua/kulala/parser/scripts/engines/javascript/lib/src/lib/PostRequest.ts
@@ -1,27 +1,34 @@
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from "fs";
+import * as path from "path";
 
-const _REQUEST_FILEPATH = path.join(__dirname, '..', '..', 'request.json');
-const _REQUEST_VARIABLES_FILEPATH = path.join(__dirname, 'request_variables.json');
+import { getObjectValueByPath, setObjectValueByPath } from "./Utils";
+
+const _REQUEST_FILEPATH = path.join(__dirname, "..", "..", "request.json");
+const _REQUEST_VARIABLES_FILEPATH = path.join(
+  __dirname,
+  "request_variables.json",
+);
 
 type RequestVariables = Record<string, string>;
 
 interface RequestJson {
-  headers: Record<string, string>,
-  headers_raw: Record<string, string>,
-  body_raw: string,
-  body_computed: string | undefined,
-  body: string | object,
-  method: string,
-  url_raw: string,
-  url: string,
-  environment: Record<string, string>,
-};
+  headers: Record<string, string>;
+  headers_raw: Record<string, string>;
+  body_raw: string;
+  body_computed: string | undefined;
+  body: string | object;
+  method: string;
+  url_raw: string;
+  url: string;
+  environment: Record<string, string>;
+}
 
 const getRequestVariables = (): RequestVariables => {
   let reqVariables: RequestVariables = {};
   try {
-    reqVariables = JSON.parse(fs.readFileSync(_REQUEST_VARIABLES_FILEPATH, { encoding: 'utf8' })) as RequestVariables;
+    reqVariables = JSON.parse(
+      fs.readFileSync(_REQUEST_VARIABLES_FILEPATH, { encoding: "utf8" }),
+    ) as RequestVariables;
   } catch (e) {
     // do nothing
   }
@@ -29,18 +36,22 @@ const getRequestVariables = (): RequestVariables => {
 };
 
 interface HeaderObject {
-  name: () => string,
-  getRawValue: () => string,
-  tryGetSubstituted: () => string,
-};
+  name: () => string;
+  getRawValue: () => string;
+  tryGetSubstituted: () => string;
+}
 
-const getHeaderObject = (headerName: string, headerRawValue: string, headerValue: string | undefined): HeaderObject | null => {
+const getHeaderObject = (
+  headerName: string,
+  headerRawValue: string,
+  headerValue: string | undefined,
+): HeaderObject | null => {
   if (headerValue === undefined) {
     return null;
   }
   return {
     name: () => {
-      return headerName
+      return headerName;
     },
     getRawValue: () => {
       return headerRawValue;
@@ -51,7 +62,9 @@ const getHeaderObject = (headerName: string, headerRawValue: string, headerValue
   };
 };
 
-const req = JSON.parse(fs.readFileSync(_REQUEST_FILEPATH, { encoding: 'utf8' })) as RequestJson;
+const req = JSON.parse(
+  fs.readFileSync(_REQUEST_FILEPATH, { encoding: "utf8" }),
+) as RequestJson;
 
 export const Request = {
   body: {
@@ -67,7 +80,11 @@ export const Request = {
   },
   headers: {
     findByName: (headerName: string) => {
-      return getHeaderObject(headerName, req.headers_raw[headerName], req.headers[headerName]);
+      return getHeaderObject(
+        headerName,
+        req.headers_raw[headerName],
+        req.headers[headerName],
+      );
     },
     all: function (): HeaderObject[] {
       const h = [];
@@ -81,9 +98,10 @@ export const Request = {
     },
   },
   environment: {
-    getName: (name: string): string | null => {
-      if (name in req.environment) {
-        return req.environment[name];
+    getName: (name: string): unknown => {
+      const value = getObjectValueByPath(req.environment, name);
+      if (value !== undefined) {
+        return value;
       }
       return null;
     },
@@ -92,7 +110,7 @@ export const Request = {
         return req.environment[name];
       }
       return null;
-    }
+    },
   },
   method: req.method,
   url: {
@@ -100,7 +118,7 @@ export const Request = {
       return req.url_raw;
     },
     tryGetSubstituted: () => {
-      return req.url
+      return req.url;
     },
   },
   status: null,
@@ -111,21 +129,29 @@ export const Request = {
   variables: {
     set: function (key: string, value: string) {
       const reqVariables = getRequestVariables();
-      reqVariables[key] = value;
-      fs.writeFileSync(_REQUEST_VARIABLES_FILEPATH, JSON.stringify(reqVariables));
+      const updatedReqVariables = setObjectValueByPath(
+        reqVariables,
+        key,
+        value as unknown as Record<string, unknown>,
+      );
+      fs.writeFileSync(
+        _REQUEST_VARIABLES_FILEPATH,
+        JSON.stringify(updatedReqVariables),
+      );
     },
     get: function (key: string) {
       const reqVariables = getRequestVariables();
-      if (key in reqVariables) {
-        return reqVariables[key];
+      const value = getObjectValueByPath(reqVariables, key);
+      if (value !== undefined) {
+        return value;
       }
       return null;
-    }
+    },
   },
   replay: () => {
-    Request.variables.set('__replay_request', "true");
+    Request.variables.set("__replay_request", "true");
   },
   iteration: () => {
-    return Request.variables.get('__iteration');
-  }
+    return Request.variables.get("__iteration");
+  },
 };

--- a/lua/kulala/parser/scripts/engines/javascript/lib/src/lib/PostRequestResponse.ts
+++ b/lua/kulala/parser/scripts/engines/javascript/lib/src/lib/PostRequestResponse.ts
@@ -1,14 +1,21 @@
 /* eslint-disable @typescript-eslint/no-magic-numbers */
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from "fs";
+import * as path from "path";
 
-const _RESPONSE_HEADERS_FILEPATH = path.join(__dirname, '..', '..', 'headers.txt');
-const _RESPONSE_BODY_FILEPATH = path.join(__dirname, '..', '..', 'body.txt');
+import { getObjectValueByPath, setObjectValueByPath } from "./Utils";
+
+const _RESPONSE_HEADERS_FILEPATH = path.join(
+  __dirname,
+  "..",
+  "..",
+  "headers.txt",
+);
+const _RESPONSE_BODY_FILEPATH = path.join(__dirname, "..", "..", "body.txt");
 
 interface HeaderObject {
-  name: string,
-  value: string[],
-};
+  name: string;
+  value: string[];
+}
 
 type Headers = Record<string, HeaderObject>;
 type Body = null | string | object;
@@ -31,8 +38,10 @@ let body: Body = null;
 const headers: Headers = {};
 
 if (fs.existsSync(_RESPONSE_HEADERS_FILEPATH)) {
-  const bodyRaw = fs.readFileSync(_RESPONSE_HEADERS_FILEPATH, { encoding: 'utf8' })
-  const lines = bodyRaw.split('\n');
+  const bodyRaw = fs.readFileSync(_RESPONSE_HEADERS_FILEPATH, {
+    encoding: "utf8",
+  });
+  const lines = bodyRaw.split("\n");
   const delimiter = ":";
 
   for (const line of lines) {
@@ -41,10 +50,10 @@ if (fs.existsSync(_RESPONSE_HEADERS_FILEPATH)) {
     }
 
     const [key] = line.split(delimiter);
-    if (!headers[key]) {
+    if (!(key in headers)) {
       headers[key] = {
         name: key,
-        value: []
+        value: [],
       };
     }
 
@@ -58,7 +67,9 @@ if (fs.existsSync(_RESPONSE_HEADERS_FILEPATH)) {
 }
 
 if (fs.existsSync(_RESPONSE_BODY_FILEPATH)) {
-  const bodyRaw = fs.readFileSync(_RESPONSE_BODY_FILEPATH, { encoding: 'utf8' })
+  const bodyRaw = fs.readFileSync(_RESPONSE_BODY_FILEPATH, {
+    encoding: "utf8",
+  });
   try {
     body = JSON.parse(bodyRaw) as object;
   } catch (e) {
@@ -89,5 +100,5 @@ export const Response: ResponseType = {
   contentType: {
     mimeType: null,
     charset: null,
-  }
+  },
 };

--- a/lua/kulala/parser/scripts/engines/javascript/lib/src/lib/Utils.ts
+++ b/lua/kulala/parser/scripts/engines/javascript/lib/src/lib/Utils.ts
@@ -1,0 +1,81 @@
+const EMPTY_LENGTH = 0;
+const ONE = 1;
+const ZERO_INDEX = 0;
+
+/**
+ * Gets the value from an object based on a dot-separated path.
+ * @param obj - The object to retrieve the value from.
+ * @param path - The dot-separated path string (e.g., "a.b.c").
+ * @returns The value at the specified path, or undefined if the path does not exist.
+ * @example
+ * const obj = { a: { b: { c: 42 } } };
+ * const value = getObjectValueByPath(obj, "a.b.c");
+ * console.log(value); // Output: 42
+ * const missingValue = getObjectValueByPath(obj, "a.b.x");
+ * console.log(missingValue); // Output: undefined
+ */
+export const getObjectValueByPath = function (
+  obj: Record<string, unknown>,
+  path: string,
+): unknown {
+  if (typeof path !== "string" || path.length === EMPTY_LENGTH) {
+    return undefined;
+  }
+  const pathParts = path.split(".");
+  let current: unknown = obj;
+  for (const part of pathParts) {
+    if (
+      current !== undefined && current !== null &&
+      typeof current === "object" && part in current
+    ) {
+      current = (current as Record<string, unknown>)[part];
+    } else {
+      return undefined;
+    }
+  }
+  return current;
+};
+
+/**
+ * Sets the value of a nested object property based on a dot-separated path.
+ * If the path does not exist, it creates the necessary nested objects.
+ * @param currentObj - The original object to modify.
+ * @param path - The dot-separated path string (e.g., "a.b.c").
+ * @param value - The value to set at the specified path.
+ * @returns A new object with the updated value at the specified path.
+ * @example
+ * const obj = { a: { b: { c: 42 } } };
+ * const newObj = setObjectValueByPath(obj, "a.b.c", 100);
+ * console.log(newObj); // Output: { a: { b: { c: 100 } } }
+ * const newObj2 = setObjectValueByPath(obj, "a.b.d", 200);
+ * console.log(newObj2); // Output: { a: { b: { c: 42, d: 200 } } }
+ * const newObj3 = setObjectValueByPath(obj, "a.x.y", 300);
+ * console.log(newObj3); // Output: { a: { b: { c: 42 }, x: { y: 300 } } }
+ */
+export const setObjectValueByPath = function (
+  currentObj: Record<string, unknown>,
+  path: string,
+  value: Record<string, unknown> | string | number | boolean | null,
+): Record<string, unknown> {
+  if (typeof path !== "string" || path.length === EMPTY_LENGTH) {
+    return currentObj;
+  }
+  const pathParts = path.split(".");
+  const newObj: Record<string, unknown> = { ...currentObj };
+  let tempObj: Record<string, unknown> = newObj;
+  for (let i = ZERO_INDEX; i < pathParts.length; i++) {
+    const part = pathParts[i];
+    if (i === pathParts.length - ONE) {
+      tempObj[part] = value;
+    } else {
+      if (
+        !(part in tempObj) || typeof tempObj[part] !== "object" ||
+        tempObj[part] === null
+      ) {
+        tempObj[part] = {};
+      }
+      tempObj = tempObj[part] as Record<string, unknown>;
+    }
+  }
+  return newObj;
+};


### PR DESCRIPTION
Works in environment and variables now.

e.g. client.global.get("some.var.here") returns either null or the value

client.global.set("some.var.here", "my-value") sets correctly nested
value.

request.environment.get("some.nested.name"), will try to get the nested
value or return null if not found.

Also updated most of the packages to fix the audit report (security related stuff).