### PR TITLE
fix(ui): locally set window options

### DIFF
--- a/lua/kulala/ui/init.lua
+++ b/lua/kulala/ui/init.lua
@@ -161,7 +161,7 @@ local function open_kulala_window(buf)
   })
 
   vim.iter(wo):each(function(key, value)
-    local status, error = pcall(vim.api.nvim_set_option_value, key, value, { win = win })
+    local status, error = pcall(vim.api.nvim_set_option_value, key, value, { win = win, scope = "local" })
     if not status then Logger.error("Failed to set window option `" .. key .. "`: " .. (error or "")) end
   end)
 


### PR DESCRIPTION
Due to how local options work, when one opens another buffer from the `kulala://ui` buffer (e.g., by `gf`ing into the `Path to response` when `The size of response is > 32Kb`), the new buffer inherits the window options.

Prevent that by locally setting the options (making them only apply to the buffer shown in the window).