### PR TITLE
Fix/js scripts misleading assertions deepclone

### DIFF
--- a/lua/kulala/parser/scripts/engines/javascript/lib/src/lib/PostRequest.ts
+++ b/lua/kulala/parser/scripts/engines/javascript/lib/src/lib/PostRequest.ts
@@ -132,7 +132,7 @@ export const Request = {
       const updatedReqVariables = setObjectValueByPath(
         reqVariables,
         key,
-        value as unknown as Record<string, unknown>,
+        value,
       );
       fs.writeFileSync(
         _REQUEST_VARIABLES_FILEPATH,

--- a/lua/kulala/parser/scripts/engines/javascript/lib/src/lib/PostRequestResponse.ts
+++ b/lua/kulala/parser/scripts/engines/javascript/lib/src/lib/PostRequestResponse.ts
@@ -2,8 +2,6 @@
 import * as fs from "fs";
 import * as path from "path";
 
-import { getObjectValueByPath, setObjectValueByPath } from "./Utils";
-
 const _RESPONSE_HEADERS_FILEPATH = path.join(
   __dirname,
   "..",

--- a/lua/kulala/parser/scripts/engines/javascript/lib/src/lib/PreRequestRequest.ts
+++ b/lua/kulala/parser/scripts/engines/javascript/lib/src/lib/PreRequestRequest.ts
@@ -132,7 +132,7 @@ export const Request = {
       const updatedReqVariables = setObjectValueByPath(
         reqVariables,
         key,
-        value as unknown as Record<string, unknown>,
+        value,
       );
       fs.writeFileSync(
         _REQUEST_VARIABLES_FILEPATH,

--- a/lua/kulala/parser/scripts/engines/javascript/lib/src/lib/Utils.ts
+++ b/lua/kulala/parser/scripts/engines/javascript/lib/src/lib/Utils.ts
@@ -61,7 +61,7 @@ export const setObjectValueByPath = function (
     return currentObj;
   }
   const pathParts = path.split(".");
-  const newObj: Record<string, unknown> = { ...currentObj };
+  const newObj: Record<string, unknown> = structuredClone(currentObj);
   let tempObj: Record<string, unknown> = newObj;
   for (let i = ZERO_INDEX; i < pathParts.length; i++) {
     const part = pathParts[i];


### PR DESCRIPTION
## Description

Fixes misleading type assertions and deep clone object in js-scripts.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Tree-sitter grammar change

## Checklist

- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [ ] Code follows the project style (run `./scripts/lint.sh check-code`)
- [ ] Tests pass locally (`make test`)
- [ ] Documentation is updated (if applicable)
- [ ] Docs follow the style guide (run `./scripts/lint.sh check-docs`)

### If this PR includes tree-sitter grammar changes:

- [ ] Updated version in `lua/tree-sitter/tree-sitter.json`
- [ ] Built tree-sitter (`tree-sitter generate && tree-sitter build`)
- [ ] Verified no parse errors in HTTP files
- [ ] Did NOT auto-update tree snapshots (only update when explicitly requested)

## Related Issues

https://github.com/mistweaverco/kulala.nvim/pull/810#issuecomment-3737246511