### PR TITLE
fix(parser): use '--head' instead of '-X HEAD' for HEAD requests

### DIFF
--- a/lua/kulala/parser/request.lua
+++ b/lua/kulala/parser/request.lua
@@ -572,8 +572,13 @@ local function build_curl_command(request)
 
   _ = #request.request_target > 0 and vim.list_extend(request.cmd, { "--request-target", request.request_target })
 
-  table.insert(request.cmd, "-X")
-  table.insert(request.cmd, request.method)
+  if request.method == "HEAD" then
+    table.insert(request.cmd, "--head") -- cURL manual says that we must use '--head' for HEAD instead of '-X HEAD'
+  else
+    table.insert(request.cmd, "-X")
+    table.insert(request.cmd, request.method)
+  end
+
   table.insert(request.cmd, "-v") -- verbose mode
 
   _ = request.http_version and table.insert(request.cmd, "--http" .. request.http_version)


### PR DESCRIPTION
## Description

Kulala was hanging indefinitely when executing HEAD requests. cURL requires the '--head' flag for proper HEAD requests; using '-X HEAD' causes the request to wait for a response body that never arrives

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Tree-sitter grammar change

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] Code follows the project style (run `./scripts/lint.sh check-code`)
- [x] Tests pass locally (`make test`) **(See notes below)**
- [x] Documentation is updated (if applicable)
- [x] Docs follow the style guide (run `./scripts/lint.sh check-docs`)

## Tests
I ran the tests with `make test_ci`. It passed. However, I received the following error when running `make test`:

```text
nvim -l tests/minit.lua tests --shuffle-tests -o utfTerminal -Xoutput --color -v
●Please install GitHub CLI to create issues.✱●●●◌●●●●●●●●●●●●●●◌●◌●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●nvim: /usr/src/debug/neovim/neovim/src/nvim/grid.c:591: grid_line_flush: Assertion `grid_line_clear_to <= grid_line_maxcol' failed.
make: *** [Makefile:26: test] Aborted (core dumped)
```

This error occurs even before my changes, so I don't think my commit is the cause.

Neovim info :

```sh
nvim --version
```

```text
NVIM v0.11.5
Build type: RelWithDebInfo
LuaJIT 2.1.1767980792
Run "nvim -V1 -v" for more info
```

OS info (`fastfetch`, cropped):

```text
OS: Arch Linux x86_64
Kernel: Linux 6.18.6-arch1-1
Shell: zsh 5.9
Display (LS22D300G): 1920x1080 in 22", 60 Hz [External]
WM: Hyprland 0.53.3 (Wayland)
Terminal: WezTerm 20240203-110809-5046fc22
```
