### PR TITLE
feat: Add config to toggle HTTPVersion append

### DIFF
--- a/doc/kulala.http-file-spec.txt
+++ b/doc/kulala.http-file-spec.txt
@@ -16,7 +16,8 @@ Table of Contents                    *kulala.http-file-spec-table-of-contents*
 REQUESTS
 
 Kulala supports `absolute`, `origin` and `asterisk path` formats for HTTP
-request.
+request. absolute format is enabled by default, you can toggle the HTTPVersion append via
+`opts.lsp.formatter.http_version_append`.
 
 `Absolute` format: `HTTPMethod` `URL` `HTTPVersion`:
 

--- a/lua/kulala/config/defaults.lua
+++ b/lua/kulala/config/defaults.lua
@@ -248,6 +248,7 @@ local M = {
       },
       quote_json_variables = true, -- add quotes around {{variable}} in JSON bodies
       indent = 2, -- base indentation for scripts
+      http_version_append = true, -- toggle HTTPVersion append
     },
 
     on_attach = nil, -- function called when Kulala LSP attaches to the buffer

--- a/lua/kulala/formatter/formatter.lua
+++ b/lua/kulala/formatter/formatter.lua
@@ -379,7 +379,11 @@ format_rules = {
 
     if #target_url > 0 then -- format url and request children only if url is present
       format_children(node)
-      request.url = ("%s %s %s"):format(method, request.url, http_version)
+      if format_opts.http_version_append then
+        request.url = ("%s %s %s"):format(method, request.url, http_version)
+      else
+        request.url = ("%s %s"):format(method, request.url)
+      end
     end
 
     _ = #request.pre_request_script > 0


### PR DESCRIPTION
- This resolves issue (#840)

## Description

Briefly describe what this PR does

> [!NOTE]
> Please open your PR against `develop` branch.  It will be merged into develop and in ~5-7 days merged into main 
> as part of `Weekly updates PR`.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Refactoring
- [ ] Tree-sitter grammar change

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] Code follows the project style (run `./scripts/lint.sh check-code`)
- [ ] Tests pass locally (`make test`)
- [x] Documentation is updated (if applicable)
- [ ] Docs follow the style guide (run `./scripts/lint.sh check-docs`)

> [!NOTE]
> Neovim help files will be generated automatically from `.md` documentation, so no need to edit `.txt` files manually.

### If this PR includes tree-sitter grammar changes:

- [ ] Updated version in `lua/tree-sitter/tree-sitter.json`
- [ ] Built tree-sitter (`tree-sitter generate && tree-sitter build`)
- [ ] Verified no parse errors in HTTP files
- [ ] Did NOT auto-update tree snapshots (only update when explicitly requested)

## Related Issues

- Closes mistweaverco/kulala-core#38
