### PR TITLE
fix(export): omit protocol from Postman URL when it cannot be determined

### DIFF
--- a/lua/kulala/cmd/export.lua
+++ b/lua/kulala/cmd/export.lua
@@ -183,7 +183,7 @@ local function get_url(request)
   local url = new(Postman.url, { raw = request.url })
 
   local protocol, rest = request.url:match("^([^:]+)://(.*)$")
-  url.protocol = protocol or "http"
+  url.protocol = protocol
 
   rest = protocol and rest or request.url
 

--- a/tests/functional/export_spec.lua
+++ b/tests/functional/export_spec.lua
@@ -190,7 +190,7 @@ describe("export to Postman", function()
 
     assert.has_properties(item.request.url, {
       raw = "httpbin.org/post",
-      protocol = "http",
+      protocol = nil,
     })
 
     sort(item.request.body.urlencoded, "key")


### PR DESCRIPTION
## Description

When exporting a request that uses a variable as the base URL (e.g. `{{url}}/health`),
the `get_url` function falls back to `protocol = "http"` because the regex doesn't match.
This causes Postman to prepend `http://` on top of the variable value, resulting in
`http://https://example.com/health` when the variable contains a full URL like `https://example.com`.

The fix is to remove the `or "http"` fallback so `protocol` stays `nil` when it can't be
determined. Postman derives the protocol from the `raw` field anyway, so omitting it is
correct behavior per the Postman collection schema.

**Before:**
```lua
url.protocol = protocol or "http"
```

**After:**
```lua
url.protocol = protocol
```

> [!NOTE]
> Please open your PR against `develop` branch.  It will be merged into develop and in ~5-7 days merged into main 
> as part of `Weekly updates PR`.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Tree-sitter grammar change

## Checklist
- [X] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [X] Code follows the project style (run `./scripts/lint.sh check-code`)
- [ ] Tests pass locally (`make test`)
- [ ] Documentation is updated (if applicable)
- [ ] Docs follow the style guide (run `./scripts/lint.sh check-docs`)

> [!NOTE]
> Neovim help files will be generated automatically from `.md` documentation, so no need to edit `.txt` files manually.

### If this PR includes tree-sitter grammar changes:
- [ ] Updated version in `lua/tree-sitter/tree-sitter.json`
- [ ] Built tree-sitter (`tree-sitter generate && tree-sitter build`)
- [ ] Verified no parse errors in HTTP files
- [ ] Did NOT auto-update tree snapshots (only update when explicitly requested)

## Related Issues

N/A