### PR TITLE
fix(default_env, multi-reqs): default_env and multi-reqs/shared-flow

### DIFF
--- a/lua/kulala/cmd/init.lua
+++ b/lua/kulala/cmd/init.lua
@@ -111,6 +111,7 @@ local REPLAY_RUNTIME_FIELDS = {
   "_kulala_script_console",
   "_kulala_limit_line",
   "_kulala_replay_run_opts",
+  "_kulala_batch_targets",
   "body_computed",
 }
 
@@ -718,9 +719,24 @@ local function kulala_core_collect_prompt_inputs(prompt)
   return out
 end
 
+---@param requests DocumentRequest[]
+---@return table[]|nil limit kulala-core run limit (name filters), or nil when empty
+local function kulala_core_batch_limit(requests)
+  local limit = {}
+  for _, req in ipairs(requests) do
+    local name = req._kulala_block_name
+    if type(name) == "string" and name ~= "" then table.insert(limit, { filter = "name", name = name }) end
+  end
+  if #limit == 0 then return nil end
+  return limit
+end
+
 ---@param parsed_request DocumentRequest
 ---@return DocumentRequest[]
 local function kulala_core_run_targets(parsed_request)
+  if type(parsed_request._kulala_batch_targets) == "table" and #parsed_request._kulala_batch_targets > 0 then
+    return parsed_request._kulala_batch_targets
+  end
   if parsed_request._kulala_run_expander and parsed_request.nested_requests and #parsed_request.nested_requests > 0 then
     return parsed_request.nested_requests
   end
@@ -836,9 +852,10 @@ end
 local function kulala_core_deliver_run_results(wrapper, parsed_request, duration_wall, callback)
   local data = wrapper.data or {}
   local targets = kulala_core_run_targets(parsed_request)
+  local multi_target = #targets > 1
   for i, item in ipairs(data) do
     local advance_queue = i == #data
-    local invoke_ui_callback = advance_queue
+    local invoke_ui_callback = multi_target or advance_queue
     local target = kulala_core_target_for_item(item, targets, i)
     kulala_core_deliver_result(item, target, duration_wall, callback, advance_queue, invoke_ui_callback)
   end
@@ -1057,17 +1074,39 @@ M.run_parser = function(requests, line_nr, callback, run_opts)
 
   local limit_line = (type(line_nr) == "number" and line_nr > 0) and line_nr or nil
 
-  for batch_index, request in ipairs(requests) do
-    if request._kulala_core and limit_line then request._kulala_limit_line = limit_line end
+  -- One kulala-core run keeps JetBrains execution-flow state (e.g. client.global.headers).
+  if #requests > 1 then
+    local anchor = requests[1]
+    if anchor._kulala_core and limit_line then anchor._kulala_limit_line = limit_line end
+    anchor._kulala_batch_targets = requests
 
-    INLAY.show(DB.current_buffer, "loading", INLAY.icon_line_for_request(request))
+    for _, request in ipairs(requests) do
+      INLAY.show(DB.current_buffer, "loading", INLAY.icon_line_for_request(request))
+    end
 
-    M.queue:add({ request = request, batch_index = batch_index, batch_size = #requests }, function()
-      if execute_before_request(request) then
+    local batch_run_opts = vim.tbl_extend("force", run_opts or {}, {})
+    local batch_limit = kulala_core_batch_limit(requests)
+    if batch_limit then batch_run_opts.limit = batch_limit end
+
+    M.queue:add({ request = anchor, batch_index = 1, batch_size = 1 }, function()
+      if execute_before_request(anchor) then
         initialize()
-        process_request(requests, request, callback, run_opts)
+        process_request(requests, anchor, callback, batch_run_opts)
       end
     end)
+  else
+    for batch_index, request in ipairs(requests) do
+      if request._kulala_core and limit_line then request._kulala_limit_line = limit_line end
+
+      INLAY.show(DB.current_buffer, "loading", INLAY.icon_line_for_request(request))
+
+      M.queue:add({ request = request, batch_index = batch_index, batch_size = #requests }, function()
+        if execute_before_request(request) then
+          initialize()
+          process_request(requests, request, callback, run_opts)
+        end
+      end)
+    end
   end
 
   M.queue:run_next()

--- a/lua/kulala/config/init.lua
+++ b/lua/kulala/config/init.lua
@@ -46,7 +46,8 @@ end
 
 M.setup = function(config)
   M.user_config = config or {}
-  M.options = vim.tbl_deep_extend("force", M.defaults, M.user_config)
+  -- Copy defaults so repeated setup() calls do not accumulate into the shared defaults table.
+  M.options = vim.tbl_deep_extend("force", vim.deepcopy(M.defaults), M.user_config)
 
   set_legacy_options()
   Parser.set_kulala_parser()

--- a/lua/kulala/init.lua
+++ b/lua/kulala/init.lua
@@ -107,7 +107,13 @@ M.get_selected_env = function()
 end
 
 M.set_selected_env = function(env)
-  vim.g.kulala_selected_env = env or require("kulala.ui.env_manager").open() or vim.g.kulala_selected_env
+  if type(env) == "string" and env ~= "" then
+    vim.g.kulala_selected_env = env
+    require("kulala.db").update().selected_env = env
+    return env
+  end
+  require("kulala.ui.env_manager").open()
+  return M.get_selected_env()
 end
 
 ---Clears all cached files

--- a/lua/kulala/parser/env.lua
+++ b/lua/kulala/parser/env.lua
@@ -108,7 +108,16 @@ M.update_http_client_auth = function(config_id, data)
 end
 
 M.get_current_env = function()
-  return vim.g.kulala_selected_env or Config.get().default_env
+  local selected = vim.g.kulala_selected_env
+  if type(selected) == "string" and selected ~= "" then return selected end
+
+  local scoped = DB.find_unique("selected_env")
+  if type(scoped) == "string" and scoped ~= "" then return scoped end
+
+  local configured = Config.get().default_env
+  if type(configured) == "string" and configured ~= "" then return configured end
+
+  return "default"
 end
 
 M.get_env = function()

--- a/lua/kulala/ui/env_manager.lua
+++ b/lua/kulala/ui/env_manager.lua
@@ -235,6 +235,7 @@ end
 local function select_env(env)
   Logger.info("Selected environment: " .. env)
   vim.g.kulala_selected_env = env
+  DB.update().selected_env = env
 end
 
 local function set_buffer(buf, content)

--- a/lua/kulala/ui/report.lua
+++ b/lua/kulala/ui/report.lua
@@ -29,7 +29,7 @@ local function set_response_summary(buf)
   local assert_status = response.assert_status and "success" or (response.assert_status == false and "failed" or "-")
   local idx = UI.get_current_response_pos()
   local duration = UI_utils.pretty_ms(response.duration)
-  local cur_env = vim.g.kulala_selected_env or CONFIG.get().default_env
+  local cur_env = require("kulala.parser.env").get_current_env()
 
   local data = vim
     .iter({

--- a/tests/config/default_env_spec.lua
+++ b/tests/config/default_env_spec.lua
@@ -1,0 +1,20 @@
+local CONFIG = require("kulala.config")
+local ENV = require("kulala.parser.env")
+
+describe("default_env", function()
+  before_each(function()
+    vim.g.kulala_selected_env = nil
+    require("kulala").setup(require("test_helper.kulala_core").config { default_env = "dev" })
+    require("kulala.db").update().selected_env = nil
+  end)
+
+  it("uses default_env from setup when no env is selected", function()
+    assert.are.equal("dev", ENV.get_current_env())
+    assert.are.equal("dev", require("kulala").get_selected_env())
+  end)
+
+  it("keeps default_env after a second setup with unrelated options", function()
+    CONFIG.setup { global_keymaps = false }
+    assert.are.equal("dev", ENV.get_current_env())
+  end)
+end)


### PR DESCRIPTION
default_env can be used to override the default environment again. Also fixed the send all requests that previously trigggered kulala-core multiple times, instead of once, which resulted in a non-shared-flow state.

With the shared-flow state that is now properly set, global state (like headers) is now shared across requests.