### PR TITLE
fix(oauth): optional client secret for password grant

### DIFF
--- a/lua/kulala/cmd/oauth.lua
+++ b/lua/kulala/cmd/oauth.lua
@@ -509,7 +509,7 @@ end
 
 M.acquire_password_token = function(config_id)
   local config = get_auth_config(config_id)
-  local required_params = { "Client ID", "Client Secret", "Token URL", "Username", "Password" }
+  local required_params = { "Client ID", "Token URL", "Username", "Password" }
   if not validate_auth_params(config_id, required_params) then return end
 
   local headers = get_custom_headers(config_id)


### PR DESCRIPTION
## Description

I have an OAuth configuration using the "password" grant type that works perfectly in IntelliJ and VS Code (httpYac) but fails in Kulala because of the requirement for a "Client Secret" value. After removing it from the required params, it works like expected.

> [!NOTE]
> Please open your PR against `develop` branch.  It will be merged into develop and in ~5-7 days merged into main 
> as part of `Weekly updates PR`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Tree-sitter grammar change

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] Code follows the project style (run `./scripts/lint.sh check-code`)
- [ ] Tests pass locally (`make test`)
- [ ] Documentation is updated (if applicable)
- [ ] Docs follow the style guide (run `./scripts/lint.sh check-docs`)

> [!NOTE]
> Neovim help files will be generated automatically from `.md` documentation, so no need to edit `.txt` files manually.

### If this PR includes tree-sitter grammar changes:

- [ ] Updated version in `lua/tree-sitter/tree-sitter.json`
- [ ] Built tree-sitter (`tree-sitter generate && tree-sitter build`)
- [ ] Verified no parse errors in HTTP files
- [ ] Did NOT auto-update tree snapshots (only update when explicitly requested)
