### PR TITLE
feat(ui): winbar scroll + ft tweaks + opts.split_direction enhancements

### DIFF
--- a/lua/kulala/config/defaults.lua
+++ b/lua/kulala/config/defaults.lua
@@ -70,8 +70,8 @@ local M = {
   ui = {
     -- display mode: possible values: "split", "float"
     display_mode = "split",
-    -- split direction: possible values: "vertical", "horizontal"
-    split_direction = "vertical",
+    -- split direction: possible values: "above", "right", "below", "left"
+    split_direction = "right",
     -- window options to override win_config: width/height/split/vertical.., buffer/window options
     win_opts = { bo = {}, wo = {} }, ---@type kulala.ui.win_config
     -- default view: "body" or "headers" or "headers_body" or "verbose" or fun(response: Response)
@@ -80,7 +80,7 @@ local M = {
     winbar = true,
     -- Specify the panes to be displayed by default
     -- Available panes are { "body", "headers", "headers_body", "script_output", "stats", "verbose", "report", "help" },
-    default_winbar_panes = { "body", "headers", "headers_body", "verbose", "script_output", "report", "help" },
+    default_winbar_panes = { "body", "headers", "verbose", "script_output", "report" },
     -- Winbar labels
     winbar_labels = {
       body = "Body",

--- a/lua/kulala/config/keymaps.lua
+++ b/lua/kulala/config/keymaps.lua
@@ -151,6 +151,20 @@ M.default_global_keymaps = {
 
 -- Keymaps for Kulala window only
 M.default_kulala_keymaps = {
+  ["Previous tab"] = {
+    "<c-h>",
+    function()
+      require("kulala.ui").show_previous_tab()
+    end,
+    mode = { "n" },
+  },
+  ["Next tab"] = {
+    "<c-l>",
+    function()
+      require("kulala.ui").show_next_tab()
+    end,
+    mode = { "n" },
+  },
   ["Show headers"] = {
     "H",
     function()

--- a/lua/kulala/config/parser.lua
+++ b/lua/kulala/config/parser.lua
@@ -50,6 +50,7 @@ M.register_parser = function()
   ensure_site_rtp()
   sync_queries()
   vim.treesitter.language.register(parser_name, filetypes)
+  vim.treesitter.language.register("markdown", "kulala_ui")
   local backend = require("kulala.backend")
   if not Api.has_triggered_ready() and backend.is_up_to_date() then Api.trigger("ready") end
   vim.api.nvim_create_autocmd("FileType", {

--- a/lua/kulala/ui/init.lua
+++ b/lua/kulala/ui/init.lua
@@ -164,7 +164,15 @@ local function open_kulala_window(buf)
       style = "minimal",
     }
   else
-    win_config = { split = config.split_direction == "vertical" and "right" or "below", win = request_win }
+    -- INFO:
+    -- Legacy options support for split direction
+    -- as "vertical" and "horizontal" were previously usued to
+    -- indicate split direction.
+    -- We map them to the new "split" option values for backward compatibility
+    local split = config.split_direction == "vertical" and "right"
+      or config.split_direction == "horizontal" and "below"
+      or config.split_direction
+    win_config = { split = split, win = request_win }
   end
 
   win_config = vim.tbl_extend("force", win_config, win_opts)
@@ -371,6 +379,43 @@ M.show_report = function()
   show(REPORT.generate_requests_report(), "markdown", "report")
 end
 
+---Get the panes configured for the winbar and the index of the currently active pane based on the default view.
+---@return table panes A list of pane names, current_index number index of the currently active pane
+---@return number current_index of the currently active pane
+local get_winbar_panes_and_current_index = function()
+  local config = CONFIG.get()
+  local panes = config.ui.default_winbar_panes
+  local current_view = config.default_view
+  local current_index
+  for idx, pane in ipairs(panes) do
+    if pane == current_view then current_index = idx end
+  end
+
+  return panes, current_index
+end
+
+M.show_previous_tab = function()
+  local panes, current_index = get_winbar_panes_and_current_index()
+  local previous_index = current_index > 1 and (current_index - 1) or #panes
+  local previous_view = panes[previous_index]
+
+  if previous_view then
+    M["show_" .. previous_view]()
+    CONFIG.options.default_view = previous_view
+  end
+end
+
+M.show_next_tab = function()
+  local panes, current_index = get_winbar_panes_and_current_index()
+  local next_index = #panes > current_index and (current_index + 1) or 1
+  local next_view = panes[next_index]
+
+  if next_view then
+    M["show_" .. next_view]()
+    CONFIG.options.default_view = next_view
+  end
+end
+
 M.show_next = function()
   local responses = DB.global_update().responses
   local current_pos = get_current_response_pos()
@@ -499,7 +544,7 @@ M.open_default_view = function()
     if open_view then open_view(get_current_response()) end
   end, debug.traceback)
 
-  if not status then Logger.error("Errors displaying response: " .. (errors or ""), 1, { report = true }) end
+  if not status then Logger.error("Errors displaying response: " .. (errors or ""), 1) end
 end
 
 M.open = function()

--- a/lua/kulala/ui/winbar.lua
+++ b/lua/kulala/ui/winbar.lua
@@ -35,36 +35,96 @@ M.toggle_winbar_tab = function(buf, win_id, view)
 
   if not (win_id and config.winbar) then return UI_utils.set_virtual_text(buf, 0, "? - help", 0, 0) end
 
+  local win_width = vim.api.nvim_win_get_width(win_id)
   local winbar_panes = config.default_winbar_panes
   local winbar_labels = config.ui.winbar_labels
-  local winbar_title = {}
+
+  local raw_tabs = {}
+  local active_index = 1
 
   for i, key in ipairs(winbar_panes) do
     local label = winbar_labels[key]
     local keymap = winbar_keymaps[key]
 
     if label then
-      local desc = "%" .. i .. "@v:lua.require'kulala.ui.winbar'.select_winbar_tab@" .. label
+      local base_text = label
 
-      if config.ui.winbar_labels_keymaps then
-        local map = keymaps[keymap]
-          and keymaps[keymap][1]
-            :gsub("<[Ll]eader>", vim.g.mapleader or "%1")
-            :gsub("<[Ll]ocalleader>", vim.g.maplocalleader or "%1")
+      if config.ui.winbar_labels_keymaps and win_width > 75 and keymaps[keymap] and keymaps[keymap][1] then
+        local map = keymaps[keymap][1]
+          :gsub("<[Ll]eader>", vim.g.mapleader or "%1")
+          :gsub("<[Ll]ocalleader>", vim.g.maplocalleader or "%1")
 
-        desc = map and desc .. " (" .. map .. ")" or desc
+        if map then base_text = base_text .. " (" .. map .. ")" end
       end
 
-      desc = view == key and "%#KulalaTabSel# " .. desc or "%#KulalaTab# " .. desc
-      desc = desc .. " %*%X"
+      local click_syntax = "%" .. i .. "@v:lua.require'kulala.ui.winbar'.select_winbar_tab@" .. base_text .. "%X"
+      local is_selected = (view == key)
 
-      table.insert(winbar_title, desc)
+      table.insert(raw_tabs, {
+        display = is_selected and "%#KulalaTabSel# " .. click_syntax or "%#KulalaTab# " .. click_syntax,
+        -- length of string text + padding spaces
+        length = #base_text + 2,
+        selected = is_selected,
+      })
+
+      if is_selected then active_index = #raw_tabs end
     end
   end
 
-  if config.ui.winbar_labels_keymaps and keymaps["Previous response"] then
-    table.insert(winbar_title, "<- " .. keymaps["Previous response"][1])
-    table.insert(winbar_title, keymaps["Next response"][1] .. " ->")
+  local available_width = win_width - 4 -- safety margin padding
+
+  if
+    config.ui.winbar_labels_keymaps
+    and keymaps["Previous response"]
+    and keymaps["Previous response"][1]
+    and win_width > 60
+  then
+    available_width = available_width - (#keymaps["Previous response"][1] + #keymaps["Next response"][1] + 8)
+  end
+
+  local start_idx = active_index
+  local end_idx = active_index
+  local current_used_width = raw_tabs[active_index] and raw_tabs[active_index].length or 0
+
+  while true do
+    local expanded = false
+    if start_idx > 1 then
+      -- account for divider space or " ..."
+      local next_len = raw_tabs[start_idx - 1].length + 7
+      if current_used_width + next_len <= available_width then
+        start_idx = start_idx - 1
+        current_used_width = current_used_width + next_len
+        expanded = true
+      end
+    end
+    if end_idx < #raw_tabs then
+      local next_len = raw_tabs[end_idx + 1].length + 3
+      if current_used_width + next_len <= available_width then
+        end_idx = end_idx + 1
+        current_used_width = current_used_width + next_len
+        expanded = true
+      end
+    end
+    if not expanded then break end
+  end
+
+  local winbar_title = {}
+  if start_idx > 1 then table.insert(winbar_title, "%#KulalaTab#...%*") end
+
+  for idx = start_idx, end_idx do
+    if raw_tabs[idx] then table.insert(winbar_title, raw_tabs[idx].display) end
+  end
+
+  if end_idx < #raw_tabs then table.insert(winbar_title, "%#KulalaTab# …%*") end
+
+  if
+    config.ui.winbar_labels_keymaps
+    and keymaps["Previous response"]
+    and keymaps["Previous response"][1]
+    and win_width > 60
+  then
+    table.insert(winbar_title, "%#KulalaTab# <- " .. keymaps["Previous response"][1] .. " %*")
+    table.insert(winbar_title, "%#KulalaTab# " .. keymaps["Next response"][1] .. " -> %*")
   end
 
   local value = table.concat(winbar_title, " ")


### PR DESCRIPTION
- winbar truncate and scroll
- register kulala_ui as markdown view with tree-sitter
- `opts.ui.split_direction` now supports `above`, `below`, `left` and `right`