### PR TITLE
feat(ui): set `shiftwidth` to 2

### DIFF
--- a/lua/kulala/ui/init.lua
+++ b/lua/kulala/ui/init.lua
@@ -106,6 +106,7 @@ local open_kulala_buffer = function(filetype)
       filetype = "kulala_ui",
       buftype = "nofile",
       syntax = filetype,
+      shiftwidth = 2,
     })
 
     vim.iter(bo):each(function(key, value)


### PR DESCRIPTION
## Description

Sets `shiftwidth` to 2. Since `foldmethod` is set to `indent`, folds may not work if `shiftwidth` is set to a value other than 2, since responses are formatted with 2 spaces as indentation.

## Type of Change

- [x] New feature

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] Code follows the project style (run `./scripts/lint.sh code`)
- [x] Tests pass locally (`./minitest.sh`)
- [ ] Documentation is updated (if applicable)
- [ ] Docs follow the style guide (run `./scripts/lint.sh docs`)
