### PR TITLE
fix(parser): don't install if managed externally

### DIFF
--- a/lua/kulala/config/parser.lua
+++ b/lua/kulala/config/parser.lua
@@ -17,16 +17,21 @@ local site_dir = vim.fs.joinpath(vim.fn.stdpath("data"), "site")
 local parser_source_path = vim.fs.joinpath(vim.fn.stdpath("data"), "kulala.nvim", "tree-sitter-kulala-http")
 local parser_registered = false
 
-local function is_parser_ver_current()
-  return require("kulala.db").settings.parser_rev == Globals.TREESITTER_VERSION
-end
-
 local function has_kulala_queries()
   return #vim.api.nvim_get_runtime_file(vim.fs.joinpath("queries", parser_name, "*.scm"), true) > 0
 end
 
 local function has_kulala_parser()
   return #vim.api.nvim_get_runtime_file(vim.fs.joinpath("parser", parser_name .. "." .. target_parser_ext), true) > 0
+end
+
+local function is_parser_ver_current()
+  local current_version = require("kulala.db").settings.parser_rev
+  if current_version == nil and has_kulala_parser() then
+    -- The parser is managed externally.
+    return true
+  end
+  return current_version == Globals.TREESITTER_VERSION
 end
 
 --- HACK:


### PR DESCRIPTION
## Description

kulala.nvim still always tries to install/build the tree-sitter parser, because `is_parser_ver_current()` returns `false` (because `db.sttings.parser_rev` is `nil`, which `~= Globals.TREESITTER_VERSION`).
If the parser is managed externally, e.g. via nix or luarocks, then it's never written to the config, so this PR modifies the function to check for `nil`.

This should still work fine if the parser is managed by kulala.nvim, because the `has_kulala_parser` and `has_kulala_queries` checks will return `false`, resulting in the parser being installed and the version being set in the DB.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Tree-sitter grammar change

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] Code follows the project style (run `./scripts/lint.sh code`)
- [x] Tests pass locally (`./minitest.sh`)
- [ ] ~Documentation is updated (if applicable)~
- [ ] ~Docs follow the style guide (run `./scripts/lint.sh docs`)~

### If this PR includes tree-sitter grammar changes:

- [ ] ~Updated version in `lua/tree-sitter/tree-sitter.json`~
- [ ] ~Built tree-sitter (`tree-sitter generate && tree-sitter build`)~
- [ ] ~Verified no parse errors in HTTP files~
- [ ] ~Did NOT auto-update tree snapshots (only update when explicitly requested)~

## Related Issues

Follow-up to #942.
