### PR TITLE
feat: allow passing function to split_direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ require("lazy").setup({
       ui = {
         -- display mode: possible values: "split", "float"
         display_mode = "split",
-        -- split direction: possible values: "above", "right", "below", "left"
+        -- split direction: possible values: "above", "right", "below", "left", fun(): "above"|"right"|"below"|"left"
         split_direction = "right",
         -- window options to override win_config: width/height/split/vertical.., buffer/window options
         win_opts = { bo = {}, wo = {} }, ---@type kulala.ui.win_config

--- a/doc/kulala.configuration-options.txt
+++ b/doc/kulala.configuration-options.txt
@@ -516,6 +516,7 @@ Possible values:
 - `"above"`, `"right"`, `"below"`, `"left"`
 - `"vertical"` (alias for `"right"`)
 - `"horizontal"` (alias for `"below"`)
+- Function returning any of `"above"`, `"right"`, `"below"`, `"left"`
 
 Default: `"right"`
 

--- a/lua/kulala/config/defaults.lua
+++ b/lua/kulala/config/defaults.lua
@@ -48,7 +48,7 @@ local M = {
   ui = {
     -- display mode: possible values: "split", "float"
     display_mode = "split",
-    -- split direction: possible values: "above", "right", "below", "left"
+    -- split direction: possible values: "above", "right", "below", "left", fun(): "above"|"right"|"below"|"left"
     split_direction = "right",
     -- window options to override win_config: width/height/split/vertical.., buffer/window options
     win_opts = { bo = {}, wo = {} }, ---@type kulala.ui.win_config

--- a/lua/kulala/types/init.lua
+++ b/lua/kulala/types/init.lua
@@ -50,7 +50,7 @@
 
 ---@class KulalaDefaultConfigUi
 ---@field display_mode "split"|"float"
----@field split_direction "above"|"right"|"below"|"left"|"vertical"|"horizontal"
+---@field split_direction "above"|"right"|"below"|"left"|"vertical"|"horizontal"|fun(): "above"|"right"|"below"|"left"
 ---@field win_opts kulala.ui.win_config
 ---@field default_view "body"|"headers"|"headers_body"|"verbose"|"report"|fun(response: Response)
 ---@field winbar boolean

--- a/lua/kulala/ui/init.lua
+++ b/lua/kulala/ui/init.lua
@@ -193,7 +193,7 @@ local function open_kulala_window(buf)
     local split = config.split_direction == "vertical" and "right"
       or config.split_direction == "horizontal" and "below"
       or config.split_direction
-    win_config = { split = split, win = request_win }
+    win_config = { split = type(split) == "function" and split() or split, win = request_win }
   end
 
   win_config = vim.tbl_extend("force", win_config, win_opts)


### PR DESCRIPTION
## Description

Hi, sometimes I run Kulala in a monitor in portrait mode, so horizontal width is limited, with split_direction as a function, I have this:

```lua
        split_direction = function()
          if vim.opt.columns:get() < 120 then
            return 'below'
          else
            return 'right'
          end
        end,
```

This allows me to dynamically set the Kulala output position

> [!NOTE]
> Please open your PR against the `main` branch.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Tree-sitter grammar change

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] Code follows the project style (run `./scripts/lint.sh code`)
- [ ] Tests pass locally (`./minitest.sh`)
- [x] Documentation is updated (if applicable)
- [ ] Docs follow the style guide (run `./scripts/lint.sh docs`)

### If this PR includes tree-sitter grammar changes:

- [ ] Updated version in `lua/tree-sitter/tree-sitter.json`
- [ ] Built tree-sitter (`tree-sitter generate && tree-sitter build`)
- [ ] Verified no parse errors in HTTP files
- [ ] Did NOT auto-update tree snapshots (only update when explicitly requested)

## Related Issues

None I think of
