### PR TITLE
fix(show_help): ignore keymaps set to false

### DIFF
--- a/lua/kulala/ui/init.lua
+++ b/lua/kulala/ui/init.lua
@@ -552,7 +552,7 @@ M.show_help = function()
   )
 
   vim.iter(keymaps):each(function(keymap, value)
-    table.insert(help, ("  - %s: `%s`"):format(keymap, value[1]))
+    if value then table.insert(help, ("  - %s: `%s`"):format(keymap, value[1])) end
   end)
 
   Float.create(help, {


### PR DESCRIPTION
## Description

Setting keymap to `false` to disable it breaks the `show_help` function. The error happens in `lua/kulala/ui/init.lua:555`
```lua
  vim.iter(keymaps):each(function(keymap, value)
    table.insert(help, ("  - %s: `%s`"):format(keymap, value[1]))
  end)
```
which tries to access `value[1]` but that value could be `false`. This PR adds a conditional to ignore such cases.

> [!NOTE]
> Please open your PR against the `main` branch.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Tree-sitter grammar change

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] Code follows the project style (run `./scripts/lint.sh code`)
- [x] Tests pass locally (`./minitest.sh`)
- [x] Documentation is updated (if applicable)
~- [ ] Docs follow the style guide (run `./scripts/lint.sh docs`)~ (this fails with `Invalid action`. Docs didn't need to change though)

## Related Issues

Fixes https://github.com/mistweaverco/kulala.nvim/issues/985